### PR TITLE
Fix genesis.json file download with overlap model

### DIFF
--- a/run-a-node/validator-node.md
+++ b/run-a-node/validator-node.md
@@ -52,8 +52,7 @@ Check the `genesis.json` file from [this link](https://github.com/0glabs/0g-chai
 
 ```bash
 sudo apt install -y unzip wget
-rm ~/.0gchain/config/genesis.json
-wget -P ~/.0gchain/config https://github.com/0glabs/0g-chain/releases/download/v0.1.0/genesis.json
+wget -O ~/.0gchain/config/genesis.json https://github.com/0glabs/0g-chain/releases/download/v0.1.0/genesis.json
 ```
 
 Then verify the correctness of the genesis configuration file:


### PR DESCRIPTION
## Fix
follow to  #5 

## Motivation
If user deploy validator node and forgot delete auto genereate genesis.json, `wget` will download file and rename to ''genesis.json.1". Use incorrect genesis file will lead to start node error.

## Modifications
`wget -O`  will download remote document with specified filename