### PR TITLE
Udhay/add to metamask button

### DIFF
--- a/docs/run-a-node/testnet-information.md
+++ b/docs/run-a-node/testnet-information.md
@@ -1,10 +1,15 @@
 ---
 sidebar_position: 3
 ---
+
+import MetaMaskButton from '@site/src/components/MetaMaskButton';
+
 # Testnet Information
 ---
 
 Welcome to Testnet-V2, where you can contribute to our network by operating various node types, including Validator, Storage, and DA (Data Availability) nodes. This page provides an overview of the testnet process and important information for participants.
+
+<MetaMaskButton />
 
 ## 0G Testnet Configuration
 

--- a/docs/run-a-node/validator-node.md
+++ b/docs/run-a-node/validator-node.md
@@ -80,7 +80,7 @@ For the testnet, due to stress testing with a large number of transactions, a fu
    0gchaind keys add <key_name> --eth
    0gchaind keys unsafe-export-eth-key <key_name>
    ```
-**8. Acquire Testnet Tokens:** Obtain testnet tokens from the 0G faucet from our [website](https://faucet.0g.ai) or by requesting them on their [Discord](disord/0glabs). These tokens are necessary for staking and becoming a validator.
+**8. Acquire Testnet Tokens:** Obtain testnet tokens from the 0G faucet from our [website](https://faucet.0g.ai) or by requesting them on their [Discord](https://discord.com/invite/0glabs). These tokens are necessary for staking and becoming a validator.
 
 **9. Become a Validator:** Register your node as a validator on the 0G network, specifying your stake amount, commission rates, and other important parameters.
 

--- a/src/components/MetaMaskButton/index.tsx
+++ b/src/components/MetaMaskButton/index.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+
+declare global {
+  interface Window {
+    ethereum?: any;
+  }
+}
+
+export default function MetaMaskButton(): JSX.Element {
+  const getChainID = (networkId: string): string => {
+    return '0x' + parseInt(networkId).toString(16);
+  };
+
+  const addNetwork = async () => {
+    if (typeof window.ethereum === 'undefined') {
+      alert('MetaMask is not installed! Please install MetaMask first.');
+      return;
+    }
+
+    const currentChainId = await window.ethereum.request({ method: 'eth_chainId' });
+    if (currentChainId === getChainID('16600')) {
+      alert('0G Testnet is already added!');
+      return;
+    }
+
+    const params = [{
+      chainId: getChainID('16600'),
+      chainName: '0G-Newton-Testnet',
+      nativeCurrency: {
+        name: 'A0GI',
+        symbol: 'A0GI',
+        decimals: 18
+      },
+      rpcUrls: ['https://evmrpc-testnet.0g.ai'],
+      blockExplorerUrls: ['https://chainscan-newton.0g.ai/']
+    }];
+
+    try {
+      await window.ethereum.request({
+        method: 'wallet_addEthereumChain',
+        params
+      });
+      alert('Network added successfully');
+    } catch (error) {
+      alert('Failed to add network');
+      console.error(error);
+    }
+  };
+
+  return (
+    <div style={{ margin: '20px 0' }}>
+      <button
+        onClick={addNetwork}
+        style={{
+          backgroundColor: '#1fa588',
+          color: 'white',
+          padding: '10px 20px',
+          border: 'none',
+          borderRadius: '5px',
+          cursor: 'pointer',
+          fontSize: '16px',
+          fontWeight: 'bold',
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: '10px'
+        }}>
+        <img
+          src="https://raw.githubusercontent.com/MetaMask/brand-resources/master/SVG/SVG_MetaMask_Icon_Color.svg"
+          alt="MetaMask Fox"
+          style={{ height: '18px' }}
+        />
+        Add 0G Testnet
+      </button>
+    </div>
+  );
+} 


### PR DESCRIPTION
This pull request introduces a new `MetaMaskButton` component to the project and integrates it into the testnet documentation. Additionally, it includes a minor correction to a URL in the validator node documentation.

### New Component Integration:

* [`src/components/MetaMaskButton/index.tsx`](diffhunk://#diff-7759b5cc5ad2139116af17a8b8da72d7b7999eb225ca9bc0b88150ec75391d2bR1-R76): Added a new `MetaMaskButton` component that allows users to add the 0G Testnet to their MetaMask wallet. This component includes functionality to check if MetaMask is installed, verify the current network, and add the 0G Testnet if it is not already added.
* [`docs/run-a-node/testnet-information.md`](diffhunk://#diff-865ede8ebe4fac533363f3dff23079bebf306cb3605083a17f4fa3ad341457c0R4-R13): Integrated the new `MetaMaskButton` component into the testnet information page to provide users with an easy way to add the 0G Testnet to their MetaMask wallet.

### Documentation Update:

* [`docs/run-a-node/validator-node.md`](diffhunk://#diff-4a039f405f20f6d21fc8c87b8ea4088e28cf3b388b2a2731376945e8161142feL83-R83): Corrected the Discord URL for acquiring testnet tokens by changing it from `disord/0glabs` to `https://discord.com/invite/0glabs`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0glabs/0g-doc/98)
<!-- Reviewable:end -->
