### PR TITLE
update the build with 0g order

### DIFF
--- a/sidebars.ts
+++ b/sidebars.ts
@@ -45,49 +45,60 @@ const sidebars: SidebarsConfig = {
       items: [
         {
           type: 'category',
-          label: 'Compute Network',
-          items: [
-            'build-with-0g/compute-network/overview',
-            'build-with-0g/compute-network/provider',
-            'build-with-0g/compute-network/sdk',
-          ],
-        },
-        'build-with-0g/storage-sdk',
-        'build-with-0g/storage-cli',
-        'build-with-0g/da-integration',
-        {
-          type: 'category',
-          label: 'Rollups and Appchains',
-          items: [
-            'build-with-0g/rollups-and-appchains/op-stack-on-0g-da',
-            'build-with-0g/rollups-and-appchains/arbitrum-nitro-on-0g-da',
-          ],
-        },
-        {
-          type: 'category',
-          label: 'Rollup-as-a-Service (coming soon)',
-          items: [
-            'build-with-0g/rollup-as-a-service/caldera-on-0g-da',
-          ],
-        },
-        {
-          type: 'category',
-          label: 'Contracts on 0G',
+          label: '0G Chain',
           items: [
             'build-with-0g/contracts-on-0g/deploy-contracts',
             {
               type: 'category',
               label: 'Precompiles',
               items: [
-                'build-with-0g/contracts-on-0g/precompiles/precompiles-overview',
-                'build-with-0g/contracts-on-0g/precompiles/precompiles-dasigners',
-                'build-with-0g/contracts-on-0g/precompiles/precompiles-staking',
                 'build-with-0g/contracts-on-0g/precompiles/precompiles-wrappeda0gibase',
+                'build-with-0g/contracts-on-0g/precompiles/precompiles-staking',
+                'build-with-0g/contracts-on-0g/precompiles/precompiles-dasigners',
               ],
             },
           ],
         },
-        'build-with-0g/marketplace',
+        {
+          type: 'category',
+          label: '0G Compute',
+          items: [
+            'build-with-0g/compute-network/overview',
+            'build-with-0g/compute-network/provider',
+            'build-with-0g/compute-network/sdk',
+            'build-with-0g/marketplace',
+          ],
+        },
+        {
+          type: 'category',
+          label: '0G Storage',
+          items: [
+            'build-with-0g/storage-sdk',
+            'build-with-0g/storage-cli',
+          ],
+        },
+        {
+          type: 'category',
+          label: '0G DA',
+          items: [
+            'build-with-0g/da-integration',
+            {
+              type: 'category',
+              label: 'Rollups and Appchains',
+              items: [
+                'build-with-0g/rollups-and-appchains/op-stack-on-0g-da',
+                'build-with-0g/rollups-and-appchains/arbitrum-nitro-on-0g-da',
+                {
+                  type: 'category',
+                  label: 'Rollup-as-a-Service (coming soon)',
+                  items: [
+                    'build-with-0g/rollup-as-a-service/caldera-on-0g-da',
+                  ],
+                },
+              ],
+            },
+          ],
+        },
         'build-with-0g/faucet',
         'build-with-0g/explorer',
       ],


### PR DESCRIPTION
# Documentation Structure Update

## Changes Made
Updated the "Build with 0G" section of the documentation to improve organization and navigation. The changes follow a more logical grouping of related features and products.

### Main Changes:
1. Reorganized "Build with 0G" into four main categories:
   - **0G Chain**
     - Contracts on 0G Chain
     - Precompiles (Wrapped Token, Stacking, DA signer)
   - **0G Compute**
     - Overview
     - Becoming a Service Provider
     - SDK
     - Marketplace (coming soon)
   - **0G Storage**
     - SDK
     - CLI
   - **0G DA**
     - DA Client Nodes
     - Rollups and Appchains
       - OP Stack on 0G DA
       - Arbitrum Nitro on 0G DA
       - Rollup-as-a-Service (coming soon)
       - Caldera on 0G DA

### Additional Updates:
- Moved Marketplace under 0G Compute section
- Grouped Storage SDK and CLI together under 0G Storage
- Restructured Rollups and Appchains as a subsection under 0G DA
- Kept Faucet and Explorer as top-level items for easy access

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0glabs/0g-doc/107)
<!-- Reviewable:end -->
