### PR TITLE
docs: fix wording issue in the introduction

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -14,7 +14,7 @@ import LottieAnimation from '@site/src/components/lottieAnimation';
 
 **0G (Zero Gravity)** is the first decentralized AI [operating system](https://edu.gcfglobal.org/en/computerbasics/understanding-operating-systems/1/) that acts as the foundational layer for decentralized AI applications and chains. It efficiently orchestrates utilization of hardware resources such as storage and compute and software assets such as data and models to handle the scale and complexity of AI workloads.
 
-Specifically designed for AI (d)applications and chains, 0G features the fastest, infinitely scalable data availability (DA) layer, the cheapest decentralized storage system, and a novel flexible serving framework for inferences and fine-tuning. Prior to 0G, resource-intensive AI applications would only be feasible "off-chain" due to burdensome on-chain costs, low latency and throughput, and a lack of builder-friendly tooling.
+Specifically designed for AI (d)applications and chains, 0G features the fastest, infinitely scalable data availability (DA) layer, the cheapest decentralized storage system, and a novel flexible serving framework for inferences and fine-tuning. Prior to 0G, resource-intensive AI applications would only be feasible "off-chain" due to burdensome on-chain costs, low latencies and throughput, and a lack of builder-friendly tooling.
 
 For the first time ever, 0G bridges this cost and efficiency gap between Web2 and Web3, empowering builders to confidently deploy AI applications on-chain with _improved_ performance.
 


### PR DESCRIPTION
i noticed a minor issue in the introduction where "low latency" was used in singular form.
since the text refers to multiple types of constraints, it should be "low latencies" instead.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0glabs/0g-doc/135)
<!-- Reviewable:end -->
