### PR TITLE
storage scan url added

### DIFF
--- a/docs/build-with-0g/explorer.md
+++ b/docs/build-with-0g/explorer.md
@@ -9,7 +9,7 @@ Our explorers provide a user-friendly window into the 0G ecosystem. By offering 
 
 These explorers provide detailed insights into storage and chain activities, helping you understand and analyze the network effectively.
 
-### [Storage Scan (coming soon)](#)
+### [Storage Scan](https://storagescan-galileo.0g.ai/)
 
 Storage Scan is your go-to tool for exploring storage-related activities within the network. Use Storage Scan to:
 - Track data storage and retrieval activities

--- a/docs/build-with-0g/storage-cli.md
+++ b/docs/build-with-0g/storage-cli.md
@@ -15,7 +15,7 @@ If you want more control over the data location and versioning, you can use 0G S
 
 ### 0G Storage Web Tool
 
-If you want a sample web based tool to upload and download your files and directories, the first simple and straightforward way is to use the Web Tool(coming soon). 
+If you want a sample web based tool to upload and download your files and directories, the first simple and straightforward way is to use the [Web Tool](https://storagescan-galileo.0g.ai/tool). 
 
 
 ## Installation
@@ -120,7 +120,7 @@ The command-line help listing is reproduced below for your convenience. The same
 **Important Considerations**
 
 *   **Contract Addresses:** You need the accurate contract addresses for the 0G log contract on the specific blockchain you are using. You can find these on the 0G Storage explorer or in the official documentation.
-*   **File Root Hash:** To download a file, you must have its root hash. This is provided when you upload a file or can be found by looking up your transaction on the 0G Storage explorer(coming soon).
+*   **File Root Hash:** To download a file, you must have its root hash. This is provided when you upload a file or can be found by looking up your transaction on the 0G [Storage explorer](https://storagescan-galileo.0g.ai/).
 *   **Storage Node RPC Endpoint:** You can use the team-deployed storage node or run your own node for more control and the potential to earn rewards.
 
 

--- a/docs/run-a-node/testnet-information.md
+++ b/docs/run-a-node/testnet-information.md
@@ -45,7 +45,7 @@ Summary Table
 | RPC | https://evmrpc-testnet.0g.ai |
 | Storage Indexer Turbo RPC | https://indexer-storage-testnet-turbo.0g.ai |
 | Chain Explorer | https://chainscan-galileo.0g.ai/ |
-| Storage Explorer | Coming Soon |
+| Storage Explorer | https://storagescan-galileo.0g.ai/ |
 | Faucet | https://faucet.0g.ai/ |
 
 ## RPCs
@@ -86,7 +86,7 @@ See [here](https://docs.0g.ai/build-with-0g/faucet) for more info.
 ### Explorers
 
 - [Chain Scan](https://chainscan-galileo.0g.ai/): Chain Scan provides a comprehensive view of 0G chain activity and transactions.
-- **Storage Scan (coming soon)**: Storage Scan is your go-to tool for exploring storage-related activities within the network.
+- **[Storage Scan](https://storagescan-galileo.0g.ai/)**: Storage Scan is your go-to tool for exploring storage-related activities within the network.
 - [Nodes Guru](https://testnet.0g.explorers.guru/): Nodes Guru provides key information and monitoring tools for validators and node operators to track the health and performance of the network.
   
 See [here](https://docs.0g.ai/build-with-0g/explorer) for more info.


### PR DESCRIPTION
Update Storage Scan and Web Tool links in documentation

- Updated the Storage Scan section to include the live URL.
- Changed the Web Tool description to link to the actual tool.
- Updated references to the Storage Explorer with the correct URL.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0glabs/0g-doc/139)
<!-- Reviewable:end -->
