### PR TITLE
New V3 details update

### DIFF
--- a/docs/run-a-node/testnet-information.md
+++ b/docs/run-a-node/testnet-information.md
@@ -27,7 +27,7 @@ export const AddNetworkSection = () => {
         </div>
         <div className="admonition-content">
           <p>
-            Before adding the 0G-Galileo testnet, please ensure you remove any old newton testnet configurations from your wallet to avoid conflicts. -
+            Before adding the 0G-Galileo testnet, please ensure you remove any old testnet configurations from your wallet to avoid conflicts. -
             <a href="#" onClick={(e) => { e.preventDefault(); setIsModalOpen(true); }} style={{marginLeft: '5px'}}>
               Need help?
             </a>
@@ -71,7 +71,7 @@ Summary Table
 | Detail | Value |
 |-------|-------|
 | Chain Name | 0G-Galileo-Testnet |
-| Chain ID | 80087 |
+| Chain ID | 16601 |
 | Token Symbol | OG |
 | RPC | https://evmrpc-testnet.0g.ai |
 | Storage Indexer Turbo RPC | https://indexer-storage-testnet-turbo.0g.ai |
@@ -91,10 +91,10 @@ The contract address might change during the public testnet phase, so please che
 
 | Component | Contract | Address |
 |-----------|----------|---------|
-| **0G Storage Turbo** | Flow Contract | `0x56A565685C9992BF5ACafb940ff68922980DBBC5` |
-| | Mine Contract | `0xB87E0e5657C25b4e132CB6c34134C0cB8A962AD6` |
-| | Market Contract | `0xf091C0e74a68Ff33d8327B2733F6e78F7BB9C827` |
-| | Reward Contract | `0x233B2768332e4Bae542824c93cc5c8ad5d44517E` |
+| **0G Storage Turbo** | Flow Contract | `0x5f1D96895e442FC0168FA2F9fb1EBeF93Cb5035e` |
+| | Mine Contract | `0xB0F6c3E2E7Ada3b9a95a1582bF6562e24A62D334` |
+| | Market Contract | `0x7644A43d43664f1Af951eC88d53ceF96bd0cFbf1` |
+| | Reward Contract | `0xdf758Bd14306482DeCbeF186eC6f18e4e79aaaE6` |
 | **0G DA** | DAEntrance Contract | `0xE75A073dA5bb7b0eC622170Fd268f35E675a957B` |
 
 Deployed Block Number: `1`

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -32,7 +32,7 @@ const sidebars: SidebarsConfig = {
       items: [
         'run-a-node/overview',
         'run-a-node/testnet-information',
-        'run-a-node/validator-node',
+        // 'run-a-node/validator-node',
         'run-a-node/storage-node',
         'run-a-node/da-node',
         'run-a-node/community-docker-repo',
@@ -94,7 +94,7 @@ const sidebars: SidebarsConfig = {
               type: 'category',
               label: 'Rollups and Appchains',
               items: [
-                'build-with-0g/rollups-and-appchains/op-stack-on-0g-da',
+                // 'build-with-0g/rollups-and-appchains/op-stack-on-0g-da',
                 'build-with-0g/rollups-and-appchains/arbitrum-nitro-on-0g-da',
                 {
                   type: 'category',

--- a/src/components/MetaMaskButton/index.tsx
+++ b/src/components/MetaMaskButton/index.tsx
@@ -24,12 +24,12 @@ export default function MetaMaskButton({ label = "Add 0G Testnet" }: MetaMaskBut
       return;
     }
 
-    const changedToGalileo = await window.ethereum.request({ method: 'wallet_switchEthereumChain', params: [{ chainId: getChainID('80087') }] }).catch(async (error: any) => {
-      // check if newton is still on the network list by try change to newton
-      const changedToNewton = await window.ethereum.request({ method: 'wallet_switchEthereumChain', params: [{ chainId: getChainID('16600') }] }).catch(async (error: any) => {        
-      // if newton is not on the network list, add galileo to the network list
+    const changedToGalileo = await window.ethereum.request({ method: 'wallet_switchEthereumChain', params: [{ chainId: getChainID('16601') }] }).catch(async (error: any) => {
+      // check if old galileo is still on the network list by try change to old galileo
+      const changedToOldGalileo = await window.ethereum.request({ method: 'wallet_switchEthereumChain', params: [{ chainId: getChainID('80087') }] }).catch(async (error: any) => {        
+      // if old galileo is not on the network list, add new galileo to the network list
       const params = [{
-        chainId: getChainID('80087'),
+        chainId: getChainID('16601'),
         chainName: '0G-Galileo-Testnet',
         nativeCurrency: {
           name: 'OG',
@@ -49,7 +49,7 @@ export default function MetaMaskButton({ label = "Add 0G Testnet" }: MetaMaskBut
         return true;
       });
 
-      if (changedToNewton) {
+      if (changedToOldGalileo) {
         return false;
       }
 
@@ -64,7 +64,7 @@ export default function MetaMaskButton({ label = "Add 0G Testnet" }: MetaMaskBut
     }
 
     const currentChainId = await window.ethereum.request({ method: 'eth_chainId' });
-    if (currentChainId === getChainID('80087')) {
+    if (currentChainId === getChainID('16601')) {
       alert('0G Testnet added');
       return;
     }

--- a/src/components/OKXButton/index.tsx
+++ b/src/components/OKXButton/index.tsx
@@ -21,7 +21,7 @@ export default function OKXButton({ label = "Add 0G Testnet" }: OKXButtonProps):
       return;
     }
 
-    const chainId = getChainID('80087');
+    const chainId = getChainID('16601');
     
     const currentChainId = await window.okxwallet.request({ method: 'eth_chainId' });
     if (currentChainId === chainId) {

--- a/src/components/RemoveNewtonModal/index.tsx
+++ b/src/components/RemoveNewtonModal/index.tsx
@@ -36,20 +36,20 @@ const RemoveNewtonModal: React.FC<RemoveNewtonModalProps> = ({ isOpen, onClose }
         {/* Modal Body */}
         <div style={styles.modalBody}>
           <p>
-            The old <strong>0G-Newton-Testnet</strong> is no longer active. 
+            The old Testnet versions are no longer active. 
             Please remove it from your MetaMask network list before adding the current <strong>0G-Galileo-Testnet</strong> to avoid potential conflicts.
           </p>
           <ol>
             <li>Open MetaMask and click the network dropdown menu at the top.</li>
             {/* TODO: Add image showing network dropdown */}
             
-            <li>Select any network <em>other</em> than <strong>0G-Newton-Testnet</strong>.</li>
+            <li>Select any network <em>other</em> than <strong>0G-Testnet</strong>.</li>
             {/* TODO: Add image showing switching network */}
             <img src="/img/step 1.png" alt="MetaMask network dropdown" style={styles.image} />
 
             <li>Open the network dropdown menu again.</li>
             
-            <li>Find <strong>0G-Newton-Testnet</strong> in the list and click the three vertical dots icon next to it.</li>
+            <li>Find <strong>0G-Testnet</strong> in the list and click the three vertical dots icon next to it.</li>
              {/* TODO: Add image showing the three dots menu */}
              <img src="/img/step 2.png" alt="Switching network" style={styles.image} />
 


### PR DESCRIPTION
Update testnet references and remove deprecated configurations

- Updated the testnet chain ID from 80087 to 16601 across multiple components.
- Updated references to the old 0G-Newton-Testnet in remove old testnet modals.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0glabs/0g-doc/146)
<!-- Reviewable:end -->
