### PR TITLE
docs(build): update release command

### DIFF
--- a/docs/run-a-node/storage-node.md
+++ b/docs/run-a-node/storage-node.md
@@ -196,7 +196,7 @@ git clone -b <latest_tag> https://github.com/0glabs/0g-storage-kv.git
 cd 0g-storage-kv
 
 # Build in release mode
-cargo build --release
+RUSTFLAGS="-C target-cpu=native" cargo build --release
 ```
 
 ## Configuration


### PR DESCRIPTION
# Pull Request

## Description
Update documentation to recommend building with
`RUSTFLAGS="-C target-cpu=native"` for release builds. Adds a note on
potential portability trade-offs for binaries compiled with `native`.

## Related Issue
Fixes #<!-- issue number -->

## Type of Change
- [ ] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Style/UI change

## Testing
- [ ] Tested locally with `yarn start`
- [ ] Build passes with `yarn build`
- [ ] Links work correctly

## Checklist
- [ ] Self-reviewed changes
- [ ] No typos or errors
- [ ] Follows project style
- [ ] Tested locally

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0glabs/0g-doc/181)
<!-- Reviewable:end -->
