### PR TITLE
Update storage node documentation to include protobuf-compiler 

### DIFF
--- a/docs/run-a-node/storage-node.md
+++ b/docs/run-a-node/storage-node.md
@@ -46,7 +46,7 @@ Start by installing all the essential tools and libraries required to build the 
 
         ```bash
         sudo apt-get update
-        sudo apt-get install clang cmake build-essential pkg-config libssl-dev
+        sudo apt-get install clang cmake build-essential pkg-config libssl-dev protobuf-compiler
         ```
 </TabItem>
   <TabItem value="mac">
@@ -169,7 +169,7 @@ Follow the same steps to install dependencies and Rust as in the storage node se
 
         ```bash
         sudo apt-get update
-        sudo apt-get install clang cmake build-essential pkg-config libssl-dev
+        sudo apt-get install clang cmake build-essential pkg-config libssl-dev protobuf-compiler
         ```
 </TabItem>
   <TabItem value="mac">


### PR DESCRIPTION
This pull request updates the installation instructions for running a storage node by adding a missing dependency to the list of required packages. The main change is the inclusion of the `protobuf-compiler` package in the setup steps for Linux systems.

Documentation updates:

* Added `protobuf-compiler` to the list of essential tools and libraries in the Linux installation instructions in `docs/run-a-node/storage-node.md`, ensuring all necessary dependencies are installed for building the storage node. [[1]](diffhunk://#diff-e82a99abffa5341b044d2916021b05ecda374e8080a052b78d9aa77a7ec6d3abL49-R49) [[2]](diffhunk://#diff-e82a99abffa5341b044d2916021b05ecda374e8080a052b78d9aa77a7ec6d3abL172-R172)


## Type of Change
- [ ] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Style/UI change

## Testing
- [ ] Tested locally with `yarn start`
- [ ] Build passes with `yarn build`
- [ ] Links work correctly

## Checklist
- [ ] Self-reviewed changes
- [ ] No typos or errors
- [ ] Follows project style
- [ ] Tested locally

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0glabs/0g-doc/189)
<!-- Reviewable:end -->
