### PR TITLE
build-error-fix

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install pnpm
+        run: npm install --global pnpm@9
+
       - name: Install Vercel CLI
         run: npm install --global vercel@latest
 

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.vercel


### PR DESCRIPTION
This pull request updates the deployment workflow by adding a step to install `pnpm` before installing the Vercel CLI. This ensures that `pnpm` is available for use in subsequent deployment steps. 

* Deployment workflow improvement:
  * [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R14-R16): Added a step to install `pnpm@9` globally before the Vercel CLI installation.# 


## Type of Change
- [ ] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Style/UI change

## Testing
- [ ] Tested locally with `yarn start`
- [ ] Build passes with `yarn build`
- [ ] Links work correctly

## Checklist
- [ ] Self-reviewed changes
- [ ] No typos or errors
- [ ] Follows project style
- [ ] Tested locally

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0glabs/0g-doc/190)
<!-- Reviewable:end -->
