### PR TITLE
fix: correct chatID retrieval logic in inference documentation

### DIFF
--- a/docs/developer-hub/building-on-0g/compute-network/inference.md
+++ b/docs/developer-hub/building-on-0g/compute-network/inference.md
@@ -572,12 +572,12 @@ if (data.usage) {
 }
 
 // For verifiable TEE services with chatID
-// First try to get chatID from response body
-let chatID = data.id || data.chatID;
+// Check response headers first
+let chatID = response.headers.get("ZG-Res-Key") || response.headers.get("zg-res-key");
 
-// If not found in response body, check response headers
+// If not found in response headers, check response body
 if (!chatID) {
-  chatID = response.headers.get("ZG-Res-Key") || response.headers.get("zg-res-key");
+  chatID = data.id || data.chatID;
 }
 
 if (chatID) {


### PR DESCRIPTION
Fix the chatID verification logic to check response headers first, then fallback to response body. Previously the documentation incorrectly suggested checking response body first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Pull Request

## Description
<!-- Brief description of your changes -->

## Related Issue
Fixes #<!-- issue number -->

## Type of Change
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Style/UI change

## Testing
- [x] Tested locally with `yarn start`
- [x] Build passes with `yarn build`
- [x] Links work correctly

## Checklist
- [x] Self-reviewed changes
- [x] No typos or errors
- [x] Follows project style
- [x] Tested locally