### PR TITLE
docs: clarify chatID retrieval principle and correct terminology

### DIFF
--- a/docs/developer-hub/building-on-0g/compute-network/inference.md
+++ b/docs/developer-hub/building-on-0g/compute-network/inference.md
@@ -803,7 +803,7 @@ for (const line of rawBody.split('\n')) {
   } catch {}
 }
 
-// Use chatID from stream data if available, otherwise use header
+// Use chatID from header if available, otherwise use chatID from stream data
 const finalChatID = chatID || streamChatID;
 
 // Process with chatID for verification if available
@@ -888,11 +888,12 @@ if (chatID) {
 - Always call `processResponse` after receiving responses to maintain proper fee management
 - The SDK automatically handles fund transfers to prevent service interruptions
 - For verifiable TEE services, the method also validates response integrity
+- **chatID retrieval principle**: Always prioritize `ZG-Res-Key` from response headers. Only use fallback methods when header is not present.
 - **chatID retrieval varies by service type:**
-  - **Chatbot**: First try `ZG-Res-Key` header, then check `response.id` or `data.chatID` as fallback
+  - **Chatbot**: First try `ZG-Res-Key` header, then check `data.id` (completion ID from response body) as fallback
   - **Text-to-Image & Speech-to-Text**: Always get chatID from `ZG-Res-Key` response header
   - **Streaming responses**:
-    - **Chatbot streaming**: Check headers first, then try to get `id` or `chatID` from stream data
+    - **Chatbot streaming**: Check headers first, then try to get `id` from stream data as fallback
     - **Speech-to-text streaming**: Get chatID from `ZG-Res-Key` header immediately
 - Usage data format varies by service type but typically includes token counts or request metrics
 


### PR DESCRIPTION
Improve documentation clarity for response handling:
- Add explicit principle: prioritize ZG-Res-Key header over fallbacks
- Correct terminology: use `data.id` (completion ID) instead of `response.id`
- Clarify streaming response comment: header takes priority over stream data
- Remove ambiguous `data.chatID` reference (non-standard field)

This ensures developers follow the correct pattern:
1. First check ZG-Res-Key response header
2. For chatbot only: fallback to data.id (OpenAI completion.id)

# Pull Request

## Description
<!-- Brief description of your changes -->

## Related Issue
Fixes #<!-- issue number -->

## Type of Change
- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Style/UI change

## Testing
- [x] Tested locally with `yarn start`
- [x] Build passes with `yarn build`
- [x] Links work correctly

## Checklist
- [x] Self-reviewed changes
- [x] No typos or errors
- [x] Follows project style
- [x] Tested locally