### PR TITLE
docs: add hosted Web UI link for compute inference

### DIFF
--- a/docs/developer-hub/building-on-0g/compute-network/inference.md
+++ b/docs/developer-hub/building-on-0g/compute-network/inference.md
@@ -94,13 +94,21 @@ All mainnet services feature TeeML verifiability for trusted execution in produc
 
 **Best for:** Quick testing, experimentation and direct frontend integration.
 
-### Installation
+### Option 1: Use the Hosted Web UI
+
+Visit the official 0G Compute Marketplace directly — no installation required:
+
+**[https://compute-marketplace.0g.ai/inference](https://compute-marketplace.0g.ai/inference)**
+
+### Option 2: Run Locally
+
+#### Installation
 
 ```bash
 pnpm add @0glabs/0g-serving-broker -g
 ```
 
-### Launch Web UI
+#### Launch Web UI
 
 ```bash
 0g-compute-cli ui start-web


### PR DESCRIPTION
Add https://compute-marketplace.0g.ai/inference as an alternative to running the local CLI, so users can access the inference UI without any installation.

# Pull Request

## Description
<!-- Brief description of your changes -->

## Related Issue
Fixes #<!-- issue number -->

## Type of Change
- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Style/UI change

## Testing
- [x] Tested locally with `yarn start`
- [x] Build passes with `yarn build`
- [x] Links work correctly

## Checklist
- [x] Self-reviewed changes
- [x] No typos or errors
- [x] Follows project style
- [x] Tested locally