### PR TITLE
docs: add Compute Router docs and restructure 0G Compute

### DIFF
--- a/docs/ai-context.md
+++ b/docs/ai-context.md
@@ -318,86 +318,77 @@ Decentralized GPU marketplace offering 90% cheaper AI workloads with OpenAI SDK 
 - **io.net**: 300,000+ GPUs across 139 countries
 - **Aethir**: 43,000+ enterprise-grade GPUs, 3,000+ H100s/H200s
 
-**Quick Start (5 minutes)**:
+**Two Integration Paths**:
+1. **Router (recommended)** — a single OpenAI-compatible API endpoint (`https://router-api.0g.ai/v1`) with one unified balance, automatic provider failover, and an API key. Best for server-side apps, agents, prototypes. Web UI: [pc.0g.ai](https://pc.0g.ai).
+2. **Direct** — connect to individual providers via the `@0glabs/0g-serving-broker` SDK, manage per-provider sub-accounts, sign each request with your wallet. Best for browser dApps with wallet signing or direct on-chain control. Web UI: [compute-marketplace.0g.ai](https://compute-marketplace.0g.ai) (or **Advanced** mode on pc.0g.ai).
 
-Install CLI:
+The two balance pools are independent — a Router deposit does not fund Direct sub-accounts and vice versa.
+
+**Quick Start — Router (Recommended)**:
+
 ```bash
-pnpm add @0glabs/0g-serving-broker -g
-```
+# 1. Visit https://pc.0g.ai, connect wallet, deposit 0G tokens
+# 2. Dashboard → API Keys → create a key with 'inference' permission (starts with sk-)
+# 3. Send a request — any OpenAI-compatible client works:
 
-Option 1 - Web UI (Easiest):
-```bash
-# Launch Web UI
-0g-compute-cli ui start-web
-
-# Open http://localhost:3090
-# Connect wallet, deposit tokens, start using AI services
-```
-
-Option 2 - CLI:
-```bash
-# Setup network
-0g-compute-cli setup-network
-
-# Login with wallet
-0g-compute-cli login
-
-# Fund account
-0g-compute-cli deposit --amount 10
-
-# List available providers
-0g-compute-cli inference list-providers
-
-# Transfer funds to provider
-0g-compute-cli transfer-fund --provider <PROVIDER_ADDRESS> --amount 5
-
-# Acknowledge provider
-0g-compute-cli inference acknowledge-provider --provider <PROVIDER_ADDRESS>
-
-# Get API key for direct access
-0g-compute-cli inference get-secret --provider <PROVIDER_ADDRESS>
-```
-
-Option 3 - Direct API (OpenAI Compatible):
-```bash
-curl <service_url>/v1/proxy/chat/completions \
+curl https://router-api.0g.ai/v1/chat/completions \
+  -H "Authorization: Bearer sk-YOUR_API_KEY" \
   -H "Content-Type: application/json" \
-  -H "Authorization: Bearer app-sk-<YOUR_SECRET>" \
   -d '{
-    "model": "<model_name>",
-    "messages": [
-      {"role": "system", "content": "You are a helpful assistant."},
-      {"role": "user", "content": "Hello!"}
-    ]
+    "model": "zai-org/GLM-5-FP8",
+    "messages": [{"role": "user", "content": "Hello!"}]
   }'
 ```
 
-**OpenAI SDK Integration**:
+**OpenAI SDK Integration (Router)**:
 ```python
 from openai import OpenAI
 
 client = OpenAI(
-    api_key="app-sk-<YOUR_SECRET>",
-    base_url="<service_url>/v1/proxy"
+    base_url="https://router-api.0g.ai/v1",
+    api_key="sk-YOUR_API_KEY"
 )
 
 response = client.chat.completions.create(
-    model="<model_name>",
-    messages=[
-        {"role": "user", "content": "Hello!"}
-    ]
+    model="zai-org/GLM-5-FP8",
+    messages=[{"role": "user", "content": "Hello!"}]
 )
 ```
 
-**Fine-tuning Models**:
-```bash
-# Prepare dataset (JSONL format)
-# Each line: {"prompt": "...", "completion": "..."}
+**Router also supports**: image generation via `POST /v1/images/generations` (OpenAI-compatible, sync) or `POST /v1/async/images/generations` + `GET /v1/async/jobs/{jobId}?provider_address=...` (recommended for production) — both paths must pass `"response_format": "b64_json"` today; URL responses will be added later. Also `/v1/audio/transcriptions`, provider routing (`provider.sort`: `latency` / `price`, or `provider.address` to pin), `GET /v1/models` (no auth), `GET /v1/account/balance`, `GET /v1/account/usage/{stats,history}`.
 
-# Upload dataset
+**Quick Start — Direct (SDK)**:
+
+```bash
+# Install CLI
+pnpm add @0glabs/0g-serving-broker -g
+
+# Setup + fund
+0g-compute-cli setup-network
+0g-compute-cli login                                    # prompts for wallet private key
+0g-compute-cli deposit --amount 10
+0g-compute-cli inference list-providers
+0g-compute-cli transfer-fund --provider <PROVIDER_ADDRESS> --amount 5  # auto-acknowledges
+
+# Get a per-provider secret key
+0g-compute-cli inference get-secret --provider <PROVIDER_ADDRESS>
+```
+
+With the per-provider secret, you call the provider's proxy directly:
+```python
+from openai import OpenAI
+client = OpenAI(
+    base_url="<service_url>/v1/proxy",
+    api_key="app-sk-<YOUR_SECRET>",
+)
+```
+
+**Fine-tuning Models** (uses the Direct account system; not available via Router):
+```bash
+# Prepare dataset (JSONL format, one {"prompt": "...", "completion": "..."} per line)
 0g-compute-cli fine-tuning upload-data --file dataset.jsonl
 
-# Create fine-tuning task
+# Create fine-tuning task (fund the fine-tuning sub-account first: transfer-fund --service fine-tuning)
 0g-compute-cli fine-tuning create-task \
   --model Qwen2.5-0.5B-Instruct \
   --dataset <DATASET_ID> \
@@ -409,9 +400,18 @@ response = client.chat.completions.create(
 
 **Documentation Links**:
 - Overview: [https://docs.0g.ai/developer-hub/building-on-0g/compute-network/overview](https://docs.0g.ai/developer-hub/building-on-0g/compute-network/overview)
-- Inference: [https://docs.0g.ai/developer-hub/building-on-0g/compute-network/inference](https://docs.0g.ai/developer-hub/building-on-0g/compute-network/inference)
+- Router (recommended):
+  - Overview: [https://docs.0g.ai/developer-hub/building-on-0g/compute-network/router/overview](https://docs.0g.ai/developer-hub/building-on-0g/compute-network/router/overview)
+  - Quickstart: [https://docs.0g.ai/developer-hub/building-on-0g/compute-network/router/quickstart](https://docs.0g.ai/developer-hub/building-on-0g/compute-network/router/quickstart)
+  - Models: [https://docs.0g.ai/developer-hub/building-on-0g/compute-network/router/models](https://docs.0g.ai/developer-hub/building-on-0g/compute-network/router/models)
+  - Chat Completions: [https://docs.0g.ai/developer-hub/building-on-0g/compute-network/router/features/chat-completions](https://docs.0g.ai/developer-hub/building-on-0g/compute-network/router/features/chat-completions)
+  - Provider Routing: [https://docs.0g.ai/developer-hub/building-on-0g/compute-network/router/routing](https://docs.0g.ai/developer-hub/building-on-0g/compute-network/router/routing)
+  - Deposits & Billing: [https://docs.0g.ai/developer-hub/building-on-0g/compute-network/router/account/deposits](https://docs.0g.ai/developer-hub/building-on-0g/compute-network/router/account/deposits)
+  - Router vs Direct: [https://docs.0g.ai/developer-hub/building-on-0g/compute-network/router/comparison](https://docs.0g.ai/developer-hub/building-on-0g/compute-network/router/comparison)
+- Direct (SDK):
+  - Inference: [https://docs.0g.ai/developer-hub/building-on-0g/compute-network/inference](https://docs.0g.ai/developer-hub/building-on-0g/compute-network/inference)
+  - Account: [https://docs.0g.ai/developer-hub/building-on-0g/compute-network/account-management](https://docs.0g.ai/developer-hub/building-on-0g/compute-network/account-management)
 - Fine-tuning: [https://docs.0g.ai/developer-hub/building-on-0g/compute-network/fine-tuning](https://docs.0g.ai/developer-hub/building-on-0g/compute-network/fine-tuning)
-- Account Management: [https://docs.0g.ai/developer-hub/building-on-0g/compute-network/account-management](https://docs.0g.ai/developer-hub/building-on-0g/compute-network/account-management)
 - Provider Setup: [https://docs.0g.ai/developer-hub/building-on-0g/compute-network/inference-provider](https://docs.0g.ai/developer-hub/building-on-0g/compute-network/inference-provider)
 
 ### 0G DA (Data Availability)

--- a/docs/concepts/compute.md
+++ b/docs/concepts/compute.md
@@ -114,7 +114,7 @@ Architecture and implementation details
 ### 🚀 For Developers
 
 Start using AI compute in 5 minutes  
-→ [Quick Start Guide](/developer-hub/building-on-0g/compute-network/inference)
+→ [Quick Start Guide](/developer-hub/building-on-0g/compute-network/router/quickstart)
 
 ### 💎 For GPU Owners
 

--- a/docs/concepts/depin.md
+++ b/docs/concepts/depin.md
@@ -95,7 +95,7 @@ The integration of 0G with DePIN infrastructure creates a comprehensive Web3 com
 Ready to build with decentralized infrastructure? Explore these resources:
 
 - [0G Compute Network](/developer-hub/building-on-0g/compute-network/overview) - Learn about 0G's compute layer
-- [Developer SDK](/developer-hub/building-on-0g/compute-network/inference) - Start building with 0G Compute
+- [Build with Compute Router](/developer-hub/building-on-0g/compute-network/router/overview) - Recommended API gateway for building with 0G Compute
 - [Developer Hub](/developer-hub/getting-started) - Get started building on 0G
 
 ---

--- a/docs/developer-hub/building-on-0g/compute-network/account-management.md
+++ b/docs/developer-hub/building-on-0g/compute-network/account-management.md
@@ -3,7 +3,7 @@ id: account-management
 title: Account
 sidebar_position: 2
 sidebar_label: Account
-description: "Manage your 0G Compute Network account. Deposit, transfer, and withdraw funds across provider sub-accounts via Web UI, CLI, or SDK."
+description: "Main account + per-provider sub-accounts used by 0G Compute's SDK-based services (Direct Inference and Fine-tuning). Deposit, transfer, refund, and withdraw via Web UI, CLI, or SDK."
 ---
 
 import Tabs from '@theme/Tabs';
@@ -11,7 +11,11 @@ import TabItem from '@theme/TabItem';
 
 # Account
 
-The 0G Compute Network uses a unified account system for managing funds across services. This guide covers how to manage your accounts using different interfaces: Web UI, CLI, and SDK.
+Both **[Direct Inference](./inference)** and **[Fine-tuning](./fine-tuning)** use the same per-provider account system: you deposit to a main account, transfer funds to each provider's sub-account, and the provider deducts from there as you use the service. This page is the shared reference for all operations — Web UI, CLI, and SDK.
+
+:::note Using the Router instead?
+The [Router](./router/overview) has its own unified billing and does **not** use per-provider sub-accounts. Router deposits, balance, API keys, and usage live elsewhere — see [Router → Deposits & Billing](./router/account/deposits) and [Router → Authentication](./router/authentication).
+:::
 
 ## Overview
 

--- a/docs/developer-hub/building-on-0g/compute-network/fine-tuning.md
+++ b/docs/developer-hub/building-on-0g/compute-network/fine-tuning.md
@@ -38,7 +38,7 @@ Enter your wallet private key when prompted.
 ### Create Account & Add Funds
 The Fine-tuning CLI requires an account to pay for service fees via the 0G Compute Network.
 
-**For detailed account management instructions, see [Account Management](./account-management).**
+**For detailed account management instructions, see [Account](./account-management).**
 
 ```bash
 # Deposit funds to your account
@@ -652,7 +652,7 @@ If `CUDA available: False`, you may need to reinstall PyTorch with the correct C
 
 ### Account Management
 
-For comprehensive account management, including viewing balances, managing sub-accounts, and handling refunds, see [Account Management](./account-management).
+For comprehensive account management, including viewing balances, managing sub-accounts, and handling refunds, see [Account](./account-management).
 
 Quick CLI commands:
 ```bash

--- a/docs/developer-hub/building-on-0g/compute-network/inference.md
+++ b/docs/developer-hub/building-on-0g/compute-network/inference.md
@@ -1,16 +1,30 @@
 ---
 id: inference
 title: Inference
-sidebar_position: 3
-description: "Run decentralized AI inference on 0G Compute Network. Use LLMs, image generation, and speech-to-text via Web UI, CLI, or SDK with OpenAI compatibility."
+sidebar_position: 1
+sidebar_label: Inference
+description: "Run inference on 0G Compute via the Direct path — connect to individual providers, manage per-provider sub-accounts, and sign requests with your wallet. Web UI, CLI, and SDK options."
 ---
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# 0G Compute Inference
+# Inference
 
-0G Compute Network provides decentralized AI inference services, supporting various AI models including Large Language Models (LLM), text-to-image generation, and speech-to-text processing.
+Run inference by connecting to individual 0G Compute providers via the `@0glabs/0g-serving-broker` SDK. You manage per-provider sub-accounts and sign every request with your wallet. For fine-tuning via the same SDK see [Fine-tuning](./fine-tuning); for funding and sub-account management see [Account](./account-management).
+
+:::tip Not sure which path to use?
+0G Compute offers **two ways** to run inference:
+
+- **[Router](./router/overview)** *(recommended for most applications)* — a single OpenAI-compatible API endpoint with one unified balance, automatic provider failover, and an API key. Use this if you're building a server-side app, agent, or prototype.
+- **Direct** *(this page)* — connect to individual providers, manage per-provider sub-accounts, and sign requests with your wallet. Use this for browser dApps with wallet signing or when you need direct on-chain control.
+
+Side-by-side comparison: [Router vs Direct](./router/comparison).
+:::
+
+:::note If your balance on pc.0g.ai looks empty
+The default **Router** view on [pc.0g.ai](https://pc.0g.ai) shows the Router balance, which is a separate on-chain pool from the per-provider sub-accounts described on this page. To see funds you've deposited on [compute-marketplace.0g.ai](https://compute-marketplace.0g.ai) (or through the CLI/SDK below), switch to **Advanced** mode using the top-right toggle on pc.0g.ai — it's the same Direct flow embedded in the new UI.
+:::
 
 ## Prerequisites
 
@@ -26,80 +40,24 @@ import TabItem from '@theme/TabItem';
 
 ## Available Services
 
-:::info Testnet Services
+The provider and model catalog changes frequently (providers join and leave, pricing is set per-provider). This page does not reproduce the list — check a live source instead:
 
-<details>
-<summary><b>View Testnet Services (2 Available)</b></summary>
+- **Web UI** — [pc.0g.ai](https://pc.0g.ai) (switch to **Advanced** mode, top-right) or [compute-marketplace.0g.ai/inference](https://compute-marketplace.0g.ai/inference) — both show the current provider catalog with pricing, health, and TEE attestation
+- **CLI** — `0g-compute-cli inference list-providers`
+- **SDK** — `await broker.inference.listService()`
 
-| # | Model | Type | Provider | Input (per 1M tokens) | Output (per 1M tokens) |
-|---|-------|------|----------|----------------------|------------------------|
-| 1 | `qwen-2.5-7b-instruct` | Chatbot | `0xa48f01...` | 0.05 0G | 0.10 0G |
-| 2 | `qwen-image-edit-2511` | Image-Edit | `0x4b2a9...` | - | 0.005 0G/image |
+### Verification modes
 
-**Available Models by Type:**
+Each service declares one of two TEE verification modes:
 
-**Chatbots (1 model):**
-- **Qwen 2.5 7B Instruct**: Fast and efficient conversational model
+**TeeML** — The AI model runs directly inside a Trusted Execution Environment. The TEE guarantees that both the model and the computation are protected, and responses are signed by the TEE's private key. Used by self-hosted models.
 
-**Image-Edit (1 model):**
-- **Qwen Image Edit 2511**: Advanced image editing and manipulation model
-
-All testnet services feature TeeML verifiability and are ideal for development and testing.
-
-</details>
-
-:::
-
-:::tip Mainnet Services
-
-<details>
-<summary><b>View Mainnet Services (7 Available)</b></summary>
-
-| # | Model | Type | Verification | Provider | Input (per 1M tokens) | Output (per 1M tokens) |
-|---|-------|------|-------------|----------|----------------------|------------------------|
-| 1 | `GLM-5-FP8` | Chatbot | TeeML | `0xd9966e...` | 1 0G | 3.2 0G |
-| 2 | `deepseek-chat-v3-0324` | Chatbot | TeeML | `0x1B3AAe...` | 0.30 0G | 1.00 0G |
-| 3 | `gpt-oss-120b` | Chatbot | TeeML | `0xBB3f5b...` | 0.10 0G | 0.49 0G |
-| 4 | `qwen3-vl-30b-a3b-instruct` | Chatbot | TeeML | `0x4415ef...` | 0.49 0G | 0.49 0G |
-| 5 | `qwen3.6-plus` | Chatbot | TeeTLS | `0x992e63...` | 0.80 0G¹ | 4.80 0G¹ |
-| 6 | `whisper-large-v3` | Speech-to-Text | TeeML | `0x36aCff...` | 0.05 0G | 0.11 0G |
-| 7 | `z-image` | Text-to-Image | TeeML | `0xE29a72...` | - | 0.003 0G/image |
-
-> ¹ **Tiered Pricing:** `qwen3.6-plus` uses input-length-based tiered pricing. Input ≤256k tokens: 0.80 / 4.80 0G. Input >256k tokens: 3.20 / 9.60 0G (×4 input, ×2 output).
-
-**Available Models by Type:**
-
-**Chatbots (5 models):**
-- **GLM-5-FP8**: High-performance reasoning model (FP8 quantized)
-- **GPT-OSS-120B**: Large-scale open-source GPT model
-- **Qwen3 VL 30B A3B Instruct**: Efficient conversational model (text-only; image input is not yet supported)
-- **Qwen3.6-Plus** *(TeeTLS)*: Alibaba's flagship LLM with hybrid linear attention and sparse MoE routing, optimized for agentic coding, multi-step workflows, and complex reasoning. 1M token context window, 119 languages. Powered by Alibaba Cloud Model Studio.
-- **DeepSeek Chat V3**: Optimized conversational model
-
-**Speech-to-Text (1 model):**
-- **Whisper Large V3**: OpenAI's state-of-the-art transcription model
-
-**Text-to-Image (1 model):**
-- **Z-Image**: Fast high-quality image generation
-
-#### Verification Modes
-
-0G Compute supports two TEE verification modes depending on how the model is hosted:
-
-**TeeML** — The AI model runs directly inside a Trusted Execution Environment. The TEE guarantees that both the model and the computation are protected, and responses are signed by the TEE's private key. Used by self-hosted models (e.g., GLM-5-FP8, DeepSeek, GPT-OSS-120B).
-
-**TeeTLS** — The Broker runs inside a TEE and proxies requests to a centralized LLM provider (e.g., Alibaba Cloud Model Studio) over HTTPS. This provides cryptographic proof that responses genuinely came from the real provider, with the following guarantees:
+**TeeTLS** — The Broker runs inside a TEE and proxies requests to a centralized LLM provider over HTTPS. This provides cryptographic proof that responses genuinely came from the real provider:
 
 - **Authentic routing**: During the TLS handshake, the Broker verifies the provider's certificate against trusted Certificate Authorities, ensuring the connection reaches the real provider — not an imposter.
 - **Cryptographic proof**: The Broker captures the provider's TLS certificate fingerprint and bundles it together with the request hash, response hash, and provider identity into a signed routing proof using its TEE-protected private key.
 - **Privacy preservation**: Since the Broker runs inside a TEE, it cannot inspect or tamper with user data in transit — 0G acts as a verifiable relay, not a middleman. This is conceptually similar to zkTLS but with stronger privacy properties, as the TEE ensures the relay itself is trustworthy.
 - **End-to-end integrity**: The TEE attestation proves the Broker is running unmodified code, the CA/TLS system guarantees only the real provider holds a valid certificate for their domain, and the TEE signature binds everything together — a verifier can confirm the proof came from a genuine TEE and that the fingerprint belongs to the expected provider.
-
-Used by centralized API-backed models (e.g., `qwen3.6-plus` via Alibaba Cloud).
-
-</details>
-
-:::
 
 ## Choose Your Interface
 
@@ -118,9 +76,10 @@ Used by centralized API-backed models (e.g., `qwen3.6-plus` via Alibaba Cloud).
 
 ### Option 1: Use the Hosted Web UI
 
-Visit the official 0G Compute Marketplace directly — no installation required:
+Two hosted entry points — both run the same Direct flow against the same per-provider sub-accounts:
 
-**[https://compute-marketplace.0g.ai/inference](https://compute-marketplace.0g.ai/inference)**
+- **[https://compute-marketplace.0g.ai/inference](https://compute-marketplace.0g.ai/inference)** — the original Marketplace UI
+- **[https://pc.0g.ai](https://pc.0g.ai)** with the top-right toggle set to **Advanced** — the same flow embedded in the new pc.0g.ai UI (the default "Router" mode on pc.0g.ai is a different, newer system — see the [Router docs](./router/overview))
 
 ### Option 2: Run Locally
 
@@ -187,7 +146,7 @@ Enter your wallet private key when prompted. This will be used for account manag
 
 ### Create Account & Add Funds
 
-Before using inference services, you need to fund your account. For detailed account management, see [Account Management](./account-management).
+Before using inference services, you need to fund your account. For detailed account management, see [Account](./account-management).
 
 ```bash
 0g-compute-cli deposit --amount 10
@@ -598,7 +557,7 @@ console.log('Reports saved to:', result.outputDirectory);
 
 ### Account Management
 
-For detailed account operations, see [Account Management](./account-management).
+For detailed account operations, see [Account](./account-management).
 
 :::info Minimum Balance Requirements
 - **Ledger creation** (`depositFund`): Requires a minimum of **3 0G** for initial deposit
@@ -956,6 +915,8 @@ if (chatID) {
 - If you see a sudden balance decrease, check your usage history — the total will match your actual usage
 
 This behavior is visible in the Web UI (provider sub-account balances), CLI (`get-account`), and SDK (`getAccount()`).
+
+**This applies only to the Direct flow.** The [Router](./router/overview) uses a different billing path with a single unified balance — there are no per-provider sub-accounts and no delayed batch settlement visible to callers.
 :::
 
 ## Rate Limits
@@ -1062,7 +1023,7 @@ pnpm add @0glabs/0g-serving-broker -g
 
 ## Next Steps
 
-- **Manage Accounts** → [Account Management Guide](./account-management)
+- **Manage Accounts** → [Account](./account-management)
 - **Fine-tune Models** → [Fine-tuning Guide](./fine-tuning)
 - **Become a Provider** → [Provider Setup](./inference-provider)
 - **View Examples** → [GitHub](https://github.com/0glabs/0g-compute-ts-starter-kit)

--- a/docs/developer-hub/building-on-0g/compute-network/marketplace.md
+++ b/docs/developer-hub/building-on-0g/compute-network/marketplace.md
@@ -1,7 +1,0 @@
----
-id: marketplace
-title: Compute Marketplace
-description: "0G Compute Network Marketplace for discovering and accessing decentralized AI compute services. Coming soon."
----
-
-Coming soon

--- a/docs/developer-hub/building-on-0g/compute-network/overview.md
+++ b/docs/developer-hub/building-on-0g/compute-network/overview.md
@@ -1,6 +1,6 @@
 ---
 id: overview
-title: Compute Network Overview
+title: Overview
 sidebar_position: 1
 description: "Overview of the 0G Compute Network — a decentralized GPU marketplace for affordable AI inference, fine-tuning, and verifiable computation."
 ---
@@ -66,10 +66,20 @@ The network consists of:
 ## Quick Start Paths
 
 ### 👨‍💻 "I want to use AI services"
-Build AI-powered applications without infrastructure:
-1. [Install SDK](./inference#sdk) - 5 minute setup
-2. [Fund your account](./account-management) - Pre-pay for usage
-3. [Send requests](./inference#direct-api-access) - **OpenAI SDK compatible**
+
+Two integration paths — pick one:
+
+**[Compute Router](./router/overview)** *(recommended for most apps)* — a single OpenAI-compatible endpoint with one unified balance, automatic provider failover, and an API key. Ideal for server-side apps, agents, and prototypes.
+1. Get an API key at [pc.0g.ai](https://pc.0g.ai)
+2. Deposit 0G tokens
+3. Point your OpenAI SDK at `https://router-api.0g.ai/v1`
+
+**[Direct](./direct)** — connect to individual providers via the `@0glabs/0g-serving-broker` SDK, manage per-provider sub-accounts, sign requests with your wallet. Use this for browser dApps with wallet signing, on-chain control, or when you need **fine-tuning** (Router is inference-only).
+1. [Install SDK](./inference) and pick a provider
+2. [Fund your account](./account-management) — shared across inference and fine-tuning
+3. Run [Inference](./inference) or [Fine-tuning](./fine-tuning)
+
+Deeper comparison: [Router vs Direct](./router/comparison).
 
 ### 🖥️ "I have GPUs to monetize"
 Turn idle hardware into revenue:
@@ -98,17 +108,15 @@ Typically 90%+ savings:
 <details>
 <summary><b>Is my data secure?</b></summary>
 
-Yes, through multiple layers:
-- TEE (Trusted Execution Environment) processing
-- No data retention by providers
-- Verifiable computation proofs
+- Every provider runs inside a TEE (Trusted Execution Environment) that isolates the serving process from external access to your inference traffic.
+- Provider responses are cryptographically signed by the TEE's private key, so you can verify the exact model that ran.
+- The Router stores only billing metadata (token counts, model, provider, timestamp) — not request or response bodies.
 </details>
 
 <details>
 <summary><b>How fast is it compared to centralized services?</b></summary>
 
-- Inference: 50-100ms latency (comparable to centralized)
-- Geographic distribution reduces latency
+Observed latency varies by model, provider load, and your distance to the provider. For chatbot workloads it is typically in the same range as centralized API services; check the provider list at [pc.0g.ai](https://pc.0g.ai) for live health and latency data per provider.
 </details>
 
 ---

--- a/docs/developer-hub/building-on-0g/compute-network/router/account/deposits.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/account/deposits.md
@@ -53,22 +53,11 @@ curl https://router-api.0g.ai/v1/account/balance \
 {
   "address": "0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65",
   "deposit_balance": "2000000000000000000",
-  "credit_balance":  "0",
-  "total_balance":   "2000000000000000000",
-  "balance":         "2000000000000000000"
+  "total_balance":   "2000000000000000000"
 }
 ```
 
-All values are in **neuron**.
-
-| Field | What it means |
-| --- | --- |
-| `deposit_balance` | Tokens the Router has pulled from your Payment Layer balance and is currently holding for your usage |
-| `credit_balance` | Promotional/grant credits, if any. Most accounts see `0` here. |
-| `total_balance` | `deposit_balance + credit_balance` — what is actually available to spend right now |
-| `balance` | Backwards-compatible alias for `total_balance` |
-
-`total_balance` may lag your Payment Layer balance slightly because the Router pulls from the Payment Layer in batches (see below). When `total_balance` hits zero and the Payment Layer is also empty, the next inference request returns `402 insufficient_balance`.
+Values are in **neuron**. `total_balance` is what is available to spend right now. It may lag your Payment Layer balance slightly because the Router pulls from the Payment Layer in batches (see below). When `total_balance` hits zero and the Payment Layer is also empty, the next inference request returns `402 insufficient_balance`.
 
 ## Check Your Usage
 

--- a/docs/developer-hub/building-on-0g/compute-network/router/account/deposits.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/account/deposits.md
@@ -1,0 +1,98 @@
+---
+id: deposits
+title: Deposits & Billing
+sidebar_position: 2
+description: "Deposit 0G tokens to the shared 0G Payment Layer, check your balance, and see how per-request cost is calculated."
+---
+
+# Deposits & Billing
+
+The Router charges on-chain, per token, from a single balance that covers every model, every provider, every service type. You deposit once; you're done until the balance runs out.
+
+:::note Separate from Direct sub-accounts
+The balance you use with the Router is distinct from the per-provider sub-accounts used by the [Direct](../../direct) flow / [compute-marketplace.0g.ai](https://compute-marketplace.0g.ai). Funds in one do not back calls in the other. See [Router vs Advanced Mode](../comparison#pc0gai-router-vs-advanced-mode) if you've been using the old flow.
+:::
+
+## Deposit
+
+You deposit to the **0G Payment Layer** — a shared balance contract used across all 0G products, not just the Router. Deposit once, and any 0G product you use (Router included) draws from the same pool.
+
+The easiest way is **[pc.0g.ai](https://pc.0g.ai) → Dashboard → Deposit**. It's a normal on-chain transaction signed by your wallet; funds are usable within a few seconds of confirmation.
+
+Payment Layer contract addresses:
+
+| Network | Address |
+|---|---|
+| Mainnet | `0xA3b15Bd2aD18BFB6b5f92D8AA9F444Dd59d1cE32` |
+| Testnet | `0x0AD9690e0b34aB2d493DE02cDF149ee34f6C9939` |
+
+## How Costs Are Calculated
+
+```
+total_cost = (input_tokens × prompt_price) + (output_tokens × completion_price)
+```
+
+- Prices are declared per model and quoted in **neuron per token** (1e18 neuron = 1 0G)
+- `input_tokens` includes the full conversation context you send (system prompt + prior messages + current user message)
+- Image and audio endpoints price per request or per second depending on the model — see the catalog
+
+Get current prices from [`GET /v1/models`](../models) or the model card on [pc.0g.ai](https://pc.0g.ai). The Router does not add markup — what the provider charges is what you pay.
+
+:::note Cached-token pricing
+Tiered pricing for cached prompt tokens is on the roadmap — a future release will report cached and fresh input tokens separately and bill them at distinct rates.
+:::
+
+## Check Your Balance
+
+```bash
+curl https://router-api.0g.ai/v1/account/balance \
+  -H "Authorization: Bearer sk-YOUR_API_KEY"
+```
+
+```json
+{
+  "address": "0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65",
+  "deposit_balance": "9000000000000000000",
+  "total_balance": "9000000000000000000"
+}
+```
+
+Values are in **neuron**. `total_balance` is what's available to the Router *right now* — it may lag your Payment Layer balance slightly because the Router pulls from the Payment Layer in batches (see below). When `total_balance` hits zero and the Payment Layer is also empty, the next inference request returns `402 insufficient_balance`.
+
+## Check Your Usage
+
+Aggregate stats:
+
+```bash
+curl "https://router-api.0g.ai/v1/account/usage/stats?start_date=2026-04-01" \
+  -H "Authorization: Bearer sk-YOUR_API_KEY"
+```
+
+Returns total requests, total tokens (prompt/completion split), and total cost for the window.
+
+Per-request history:
+
+```bash
+curl "https://router-api.0g.ai/v1/account/usage/history?limit=20&offset=0" \
+  -H "Authorization: Bearer sk-YOUR_API_KEY"
+```
+
+Returns a paginated list of individual requests with model, provider address, token counts, and cost. Both endpoints also accept `api_key_id`, `source`, `start_date`, and `end_date` filters.
+
+## Related
+
+- [**Authentication**](../authentication) — how to create, rotate, and revoke the API keys billed against this balance
+- [**Rate Limits**](../rate-limits)
+- [**Errors**](../errors) — especially `402 insufficient_balance`
+
+---
+
+## How funds reach the Router (advanced)
+
+You don't need to know this to use the Router, but if you're curious about the on-chain flow:
+
+1. You deposit to the **Payment Layer** contract. The deposit belongs to your wallet address.
+2. The Router runs a background **PaymentWorker** that watches for users whose Router-side balance is below a threshold and who have an active usage pattern. For those users, the worker asks the Payment Layer to release a small tranche of your balance into the Router's internal payment contract.
+3. The Router then debits that internal contract as you consume tokens, and periodically settles the consumed amount to individual providers on-chain.
+
+This two-step design (Payment Layer → Router) means the Payment Layer balance is shared across all 0G products, and the Router only holds what it needs for your near-term usage. From your side, the only thing you interact with is the Payment Layer deposit — everything else is automatic.

--- a/docs/developer-hub/building-on-0g/compute-network/router/account/deposits.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/account/deposits.md
@@ -52,12 +52,23 @@ curl https://router-api.0g.ai/v1/account/balance \
 ```json
 {
   "address": "0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65",
-  "deposit_balance": "9000000000000000000",
-  "total_balance": "9000000000000000000"
+  "deposit_balance": "2000000000000000000",
+  "credit_balance":  "0",
+  "total_balance":   "2000000000000000000",
+  "balance":         "2000000000000000000"
 }
 ```
 
-Values are in **neuron**. `total_balance` is what's available to the Router *right now* — it may lag your Payment Layer balance slightly because the Router pulls from the Payment Layer in batches (see below). When `total_balance` hits zero and the Payment Layer is also empty, the next inference request returns `402 insufficient_balance`.
+All values are in **neuron**.
+
+| Field | What it means |
+| --- | --- |
+| `deposit_balance` | Tokens the Router has pulled from your Payment Layer balance and is currently holding for your usage |
+| `credit_balance` | Promotional/grant credits, if any. Most accounts see `0` here. |
+| `total_balance` | `deposit_balance + credit_balance` — what is actually available to spend right now |
+| `balance` | Backwards-compatible alias for `total_balance` |
+
+`total_balance` may lag your Payment Layer balance slightly because the Router pulls from the Payment Layer in batches (see below). When `total_balance` hits zero and the Payment Layer is also empty, the next inference request returns `402 insufficient_balance`.
 
 ## Check Your Usage
 

--- a/docs/developer-hub/building-on-0g/compute-network/router/authentication.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/authentication.md
@@ -1,0 +1,41 @@
+---
+id: authentication
+title: Authentication
+sidebar_position: 6
+description: "API keys are how you authenticate with the 0G Compute Router. Create them in the Web UI; send them in the Authorization header."
+---
+
+# Authentication
+
+The Router authenticates every request with an **API Key**. Each key is tied to your wallet address; usage is billed against the 0G tokens you deposited to the [Payment Layer](./account/deposits).
+
+## Sending the key
+
+Send the key in the `Authorization` header on every request:
+
+```
+Authorization: Bearer sk-YOUR_API_KEY
+```
+
+That's the whole protocol — no OAuth flow, no wallet signature per request, no session tokens.
+
+## Create and manage keys
+
+API keys are created and managed in the Web UI: **[pc.0g.ai](https://pc.0g.ai) → Dashboard → API Keys**. From there you can:
+
+- **Create** a new key — label it so you can tell keys apart (e.g. `staging`, `agent-bot`, `my-laptop`). The full secret is shown **once** on creation; copy it immediately. The dashboard only stores a hash.
+- **List** existing keys with their labels, created-at, and last-used timestamps.
+- **Revoke** any key instantly — in-flight requests using a revoked key return `401 api_key_revoked` on their next call.
+
+## Best practices
+
+- **One key per deployment.** Separate staging / production / per-service keys so you can revoke one without touching the others.
+- **Rotate on suspicion.** If a key might have leaked, revoke it and issue a new one — takes seconds.
+
+:::caution Never ship API keys to browsers
+Whoever has your key can spend the 0G tokens you deposited. Keep keys server-side and proxy client requests through your own backend — your backend holds the key, your frontend talks to your backend.
+:::
+
+:::info Coming soon
+Per-key controls such as **permission scopes**, **expiration**, and **per-key rate / token limits** are on the roadmap. Today every key grants full inference access and does not expire.
+:::

--- a/docs/developer-hub/building-on-0g/compute-network/router/comparison.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/comparison.md
@@ -1,0 +1,64 @@
+---
+id: comparison
+title: Router vs Direct
+sidebar_position: 11
+description: "Which integration path to pick — Router gateway or Direct with wallet signing."
+---
+
+# Router vs Direct
+
+The 0G Compute Network exposes the same underlying providers through two integration paths. This page helps you choose.
+
+## At a Glance
+
+|                            | **Router**                                | **[Direct](../direct)**                   |
+| -------------------------- | ----------------------------------------- | ----------------------------------------- |
+| **Where the request signs from** | Router API key (server-side)        | User's wallet (client or server)          |
+| **API shape**              | OpenAI / Anthropic compatible             | 0G SDK calls                              |
+| **Provider selection**     | Automatic with failover                   | Manual — you choose and fund each         |
+| **Billing**                | Single unified on-chain balance           | Per-provider sub-accounts                 |
+| **Browser-safe**           | Only via your backend (API keys are secret) | Yes — user's wallet signs each request   |
+| **Integration effort**     | Change `base_url` + API key               | Install SDK, manage keys, handle signing  |
+| **On-chain transparency**  | Settled periodically in batches           | Every call settles against a sub-account  |
+| **Typical user**           | Backend service, agent framework, prototype | Wallet-connected dApp, on-chain agent   |
+
+## Pick the Router When…
+
+- You're building a **server-side app** — an agent, a backend, a CLI, an automation.
+- You want to **reuse existing OpenAI/Anthropic code** without rewriting for a new SDK.
+- You don't want to manage per-provider funding or provider discovery yourself.
+- You want one balance covering every model, every service.
+- You're prototyping and want the shortest path from signup to first request.
+
+## Pick Direct When…
+
+- You're building a **browser dApp** where the end user's wallet signs requests — API keys should never ship to browsers.
+- You need **direct smart-contract interaction** — reading provider state, on-chain settlement receipts, custom escrow logic.
+- You want to **choose and fund specific providers** with tight control, not a gateway's routing policy.
+- You're writing an on-chain agent or a contract that calls providers directly.
+
+## Can I Use Both?
+
+Yes. The balances are separate (Router balance vs per-provider sub-accounts), but nothing prevents a single project from using the Router for backend workloads and Direct for a browser-wallet dApp.
+
+## pc.0g.ai: Router vs Advanced Mode
+
+The [pc.0g.ai](https://pc.0g.ai) Web UI exposes **both** integration paths through a mode toggle in the top-right:
+
+| Mode in UI                 | What it is                                                                                   | Where funds live                                                                       |
+| -------------------------- | -------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| **Router** (default)       | This documentation. Unified API gateway with a single balance.                               | 0G **Payment Layer** — shared contract across all 0G products, single pool across all models/providers |
+| **Advanced**               | The classic [Direct](../direct) flow, embedded in the new UI                             | Per-provider sub-accounts — same as [compute-marketplace.0g.ai](https://compute-marketplace.0g.ai) |
+
+**The two balance pools are independent.** A Router deposit does not fund your provider sub-accounts, and sub-account balances do not back Router API calls. They live in different contracts.
+
+### For existing compute-marketplace.0g.ai users
+
+If you've been using [compute-marketplace.0g.ai/wallet](https://compute-marketplace.0g.ai/wallet) and your funds don't appear in the default Router view on pc.0g.ai — that's expected. Click **Advanced** (top-right) to switch to the sub-account view where your existing balances are shown. Nothing has been lost; you're looking at the wrong pool.
+
+If you want to consolidate onto the Router, withdraw from the per-provider sub-accounts in Advanced mode, then deposit the tokens into the Router balance from the default view.
+
+## See Also
+
+- **[Router Overview](./overview)**
+- **[Direct](../direct)** — SDK-based path (inference, fine-tuning, and account management)

--- a/docs/developer-hub/building-on-0g/compute-network/router/errors.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/errors.md
@@ -1,0 +1,60 @@
+---
+id: errors
+title: Errors
+sidebar_position: 10
+description: "HTTP status codes and error shapes returned by the Router."
+---
+
+# Errors
+
+Errors follow a consistent OpenAI-compatible shape. The response also includes `request_id` at the top level when available — quote it when reporting issues.
+
+```json
+{
+  "error": {
+    "message": "Insufficient balance to process request",
+    "type": "payment_error",
+    "code": "insufficient_balance"
+  },
+  "request_id": "req_abc123"
+}
+```
+
+## HTTP Status Codes
+
+| Status | Meaning                                                                         |
+| ------ | ------------------------------------------------------------------------------- |
+| `400`  | Bad request — invalid model, malformed body, unsupported feature for model      |
+| `401`  | Missing or invalid authentication                                               |
+| `402`  | Insufficient balance — [deposit more](./account/deposits)                       |
+| `403`  | The API key does not have permission to perform this action                     |
+| `404`  | Resource not found                                                              |
+| `429`  | Rate limited — check `Retry-After` header, see [Rate Limits](./rate-limits)     |
+| `502`  | Provider returned an error (failover exhausted)                                 |
+| `503`  | No healthy providers available for the requested model                          |
+
+## Error Types and Codes
+
+`error.type` groups errors into a small set of buckets; `error.code` identifies the specific cause.
+
+| `type`                  | `code` (examples)                                            | When it happens                                      |
+| ----------------------- | ------------------------------------------------------------ | ---------------------------------------------------- |
+| `invalid_request_error` | `invalid_body`, `missing_authorization`, `invalid_api_key`, `api_key_revoked` | 400, 401 — request or auth is wrong |
+| `payment_error`         | `insufficient_balance`                                       | 402 — not enough 0G deposited                        |
+| `permission_error`      | `access_denied`                                              | 403 — the key is not allowed to perform this action  |
+| `not_found_error`       | `api_key_not_found`                                          | 404 — resource doesn't exist                         |
+| `rate_limit_error`      | `rate_limit_exceeded`                                        | 429 — see [Rate Limits](./rate-limits)               |
+| `server_error`          | `no_available_provider`, `provider_error`, `internal_error`  | 502, 503, 500 — backend problem                      |
+
+## Retrying
+
+- `429` — honor `Retry-After`, then retry
+- `502` (`provider_error`) — the Router already tried every healthy provider; retrying may help if one just came back online
+- `503` (`no_available_provider`) — unlikely to resolve in seconds; consider a different model or waiting
+
+Do **not** retry `400`, `401`, `402`, or `403` without changing your request — they won't succeed.
+
+## Related
+
+- [**Rate Limits**](./rate-limits)
+- [**Deposits & Billing**](./account/deposits)

--- a/docs/developer-hub/building-on-0g/compute-network/router/faq.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/faq.md
@@ -17,7 +17,7 @@ See [Router vs Advanced Mode](./comparison#pc0gai-router-vs-advanced-mode) for a
 
 ## Do I need a wallet to use the Router?
 
-Yes. The Router bills on-chain, so you need a wallet to deposit 0G tokens and create API keys. MetaMask, WalletConnect, and email sign-in (via Privy) are all supported at [pc.0g.ai](https://pc.0g.ai).
+Yes. The Router bills on-chain, so you need a wallet to deposit 0G tokens and create API keys. [pc.0g.ai](https://pc.0g.ai) supports MetaMask and WalletConnect for direct wallet connect, plus social sign-in via Privy (Google, X/Twitter, Discord, TikTok) which provisions an embedded wallet for you.
 
 Once you have an API key, your application code doesn't touch the wallet again — it just sends `Authorization: Bearer sk-…`.
 

--- a/docs/developer-hub/building-on-0g/compute-network/router/faq.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/faq.md
@@ -1,0 +1,59 @@
+---
+id: faq
+title: FAQ
+sidebar_position: 12
+description: "Frequently asked questions about the 0G Compute Router."
+---
+
+# FAQ
+
+## I deposited on compute-marketplace.0g.ai but don't see my balance on pc.0g.ai — where did my 0G go?
+
+Nowhere. Those funds live in **per-provider sub-accounts** under the [Direct](../direct) flow, and pc.0g.ai defaults to showing the **Router** balance, which is a different on-chain pool.
+
+Click the **Advanced** toggle in the top-right of pc.0g.ai. Advanced mode is the same Direct flow you've been using, just embedded in the new UI — your sub-account balances appear there.
+
+See [Router vs Advanced Mode](./comparison#pc0gai-router-vs-advanced-mode) for a side-by-side breakdown of the two systems.
+
+## Do I need a wallet to use the Router?
+
+Yes. The Router bills on-chain, so you need a wallet to deposit 0G tokens and create API keys. MetaMask, WalletConnect, and email sign-in (via Privy) are all supported at [pc.0g.ai](https://pc.0g.ai).
+
+Once you have an API key, your application code doesn't touch the wallet again — it just sends `Authorization: Bearer sk-…`.
+
+## What is TEE and why does it matter?
+
+A **Trusted Execution Environment** is a hardware-isolated region where code runs with cryptographic attestation of exactly what was executed. Every provider on the 0G Compute Network runs inside a TEE and attests to the model they serve.
+
+This is what makes "decentralized inference" meaningful: you can verify, out-of-band, that the model you asked for is the model that ran — not a silently-swapped cheaper model.
+
+## What token do I pay in?
+
+**0G tokens**, native to the 0G chain. Deposit once to the Router payment contract; the Router handles conversions and provider payouts.
+
+## Is the Router really OpenAI-compatible?
+
+Yes. Any OpenAI client library — `openai-python`, `openai-node`, LangChain, LlamaIndex, Vercel AI SDK, etc. — works by changing `base_url` to `https://router-api.0g.ai/v1` and `api_key` to your Router key.
+
+## How is pricing set?
+
+Each provider declares prices per model (input tokens, output tokens). The Router publishes these in `/v1/models`. When you route with `sort: "price"`, the cheapest provider wins; otherwise failover picks a healthy provider regardless of price.
+
+There is no Router markup on top of provider prices — what you see in the catalog is what you pay.
+
+## What happens if no providers are available?
+
+If every provider for your chosen model is unhealthy, you get `503 no_providers_available`. The Router does **not** fall back to a different model — picking a model is your decision. Choose a different model yourself, or wait and retry.
+
+## Does the Router store my prompts?
+
+No. The Router persists only billing metadata (token counts, model, provider, timestamp). Request and response bodies are not stored. If you need content audit logs, log them yourself on the caller side.
+
+## Can I run my own provider?
+
+Yes. See the [Inference Provider Setup](../inference-provider) guide. Once you're registered and healthy, the Router will start routing traffic to you alongside existing providers.
+
+## Where do I get help?
+
+- [**Discord**](https://discord.gg/0glabs) — the `#compute` channel
+- [**GitHub Issues**](https://github.com/0gfoundation) for bug reports

--- a/docs/developer-hub/building-on-0g/compute-network/router/features/audio.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/features/audio.md
@@ -70,16 +70,15 @@ print(result.text)
 
 ## 0G Router Extensions
 
-The Router supports the same routing and verification extensions as other endpoints. Because this endpoint uses `multipart/form-data`, pass these as **query parameters** rather than form fields:
+Because this endpoint uses `multipart/form-data` instead of a JSON body, the only Router extension that can be passed today is `verify_tee`, as a **query parameter**:
 
-| Query param         | Description                                                                          |
-| ------------------- | ------------------------------------------------------------------------------------ |
-| `verify_tee=true`   | Ask the Router to synchronously verify the provider's TEE signature — see [Verifiable Execution](./verifiable-execution) |
-| `provider.address`  | Pin to a specific provider — see [Routing](../routing)                               |
-| `provider.sort`     | `latency` or `price` — see [Routing](../routing)                                     |
+```
+?verify_tee=true
+```
+
+See [Verifiable Execution](./verifiable-execution) for what `tee_verified` means in the response. Provider routing fields (`provider.address`, `provider.sort`) are not currently parsed on multipart endpoints — use the default round-robin or pin via [Provider Routing](../routing) on the JSON-body endpoints.
 
 ## Related
 
 - [**Models**](../models) — list available audio models
-- [**Routing**](../routing)
 - [**Verifiable Execution**](./verifiable-execution)

--- a/docs/developer-hub/building-on-0g/compute-network/router/features/audio.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/features/audio.md
@@ -1,0 +1,85 @@
+---
+id: audio
+title: Audio Transcription
+sidebar_position: 4
+description: "Speech-to-text via the OpenAI-compatible /v1/audio/transcriptions endpoint."
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Audio Transcription
+
+**`POST /v1/audio/transcriptions`**
+
+Fully compatible with the [OpenAI Audio Transcription API](https://platform.openai.com/docs/api-reference/audio/createTranscription). Send audio as `multipart/form-data`; the OpenAI SDK does this automatically.
+
+<Tabs>
+<TabItem value="curl" label="cURL" default>
+
+```bash
+curl https://router-api.0g.ai/v1/audio/transcriptions \
+  -H "Authorization: Bearer sk-YOUR_API_KEY" \
+  -F "file=@recording.mp3" \
+  -F "model=openai/whisper-large-v3" \
+  -F "response_format=json"
+```
+
+</TabItem>
+<TabItem value="python" label="Python (OpenAI SDK)">
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://router-api.0g.ai/v1",
+    api_key="sk-YOUR_API_KEY",
+)
+
+with open("recording.mp3", "rb") as f:
+    result = client.audio.transcriptions.create(
+        model="openai/whisper-large-v3",
+        file=f,
+        response_format="json",
+    )
+
+print(result.text)
+```
+
+</TabItem>
+</Tabs>
+
+## Fields
+
+| Field             | Description                                                     |
+| ----------------- | --------------------------------------------------------------- |
+| `model`           | Audio model ID from [`/v1/models`](../models)                   |
+| `file`            | Audio file (multipart form)                                     |
+| `response_format` | `json`, `text`, `srt`, `verbose_json`, `vtt`                    |
+| `language`        | ISO-639-1 code, e.g. `"en"` — optional, improves accuracy       |
+| `prompt`          | Optional text to guide style and vocabulary                     |
+| `temperature`     | Sampling temperature (0 = deterministic)                        |
+
+## Response
+
+```json
+{
+  "text": "Hello, this is a transcription of the audio file."
+}
+```
+
+## 0G Router Extensions
+
+The Router supports the same routing and verification extensions as other endpoints. Because this endpoint uses `multipart/form-data`, pass these as **query parameters** rather than form fields:
+
+| Query param         | Description                                                                          |
+| ------------------- | ------------------------------------------------------------------------------------ |
+| `verify_tee=true`   | Ask the Router to synchronously verify the provider's TEE signature — see [Verifiable Execution](./verifiable-execution) |
+| `provider.address`  | Pin to a specific provider — see [Routing](../routing)                               |
+| `provider.sort`     | `latency` or `price` — see [Routing](../routing)                                     |
+
+## Related
+
+- [**Models**](../models) — list available audio models
+- [**Routing**](../routing)
+- [**Verifiable Execution**](./verifiable-execution)

--- a/docs/developer-hub/building-on-0g/compute-network/router/features/chat-completions.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/features/chat-completions.md
@@ -1,0 +1,169 @@
+---
+id: chat-completions
+title: Chat Completions
+sidebar_position: 1
+description: "OpenAI-compatible /v1/chat/completions with streaming, tool calling, JSON mode, and reasoning tokens."
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Chat Completions
+
+**`POST /v1/chat/completions`**
+
+Fully compatible with the [OpenAI Chat Completions API](https://platform.openai.com/docs/api-reference/chat). Supports streaming, tool calling, JSON mode, and reasoning-token models.
+
+## Request
+
+```json
+{
+  "model": "zai-org/GLM-5-FP8",
+  "messages": [
+    {"role": "system", "content": "You are a helpful assistant."},
+    {"role": "user", "content": "Explain quantum computing in simple terms."}
+  ],
+  "temperature": 0.7,
+  "max_tokens": 1024,
+  "stream": true
+}
+```
+
+All standard OpenAI fields are accepted — `temperature`, `top_p`, `n`, `stop`, `presence_penalty`, `frequency_penalty`, `logit_bias`, `user`, `response_format`, and so on.
+
+### 0G Router Extensions
+
+Optional top-level fields. Stripped before the request is forwarded to the provider, so they never conflict with the OpenAI schema.
+
+| Field        | Type    | Description                                                                          |
+| ------------ | ------- | ------------------------------------------------------------------------------------ |
+| `provider`   | object  | Control provider routing — see [Routing](../routing)                                 |
+| `verify_tee` | boolean | Ask the Router to synchronously verify the provider's TEE signature — see [Verifiable Execution](./verifiable-execution) |
+
+## Streaming
+
+Set `"stream": true` to receive Server-Sent Events in the OpenAI SSE format. Any OpenAI client library that handles streaming will work unchanged.
+
+```bash
+curl https://router-api.0g.ai/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer sk-YOUR_API_KEY" \
+  -d '{
+    "model": "zai-org/GLM-5-FP8",
+    "messages": [{"role": "user", "content": "Write a haiku about decentralization"}],
+    "stream": true
+  }'
+```
+
+:::tip Reasoning models
+Some models (e.g. GLM-5) emit a `reasoning_content` field in streaming deltas before the final `content`. Client libraries that know about reasoning tokens will surface both separately.
+:::
+
+## Tool Calling
+
+Models that advertise tool-calling capability accept the standard OpenAI `tools` / `tool_choice` fields.
+
+```json
+{
+  "model": "zai-org/GLM-5-FP8",
+  "messages": [
+    {"role": "user", "content": "What's the weather in Tokyo?"}
+  ],
+  "tools": [
+    {
+      "type": "function",
+      "function": {
+        "name": "get_weather",
+        "description": "Get current weather for a city",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "city": {"type": "string"}
+          },
+          "required": ["city"]
+        }
+      }
+    }
+  ]
+}
+```
+
+:::caution Check model capabilities
+**Not every model supports tool calling.** Before sending a request with `tools`, verify the model's capability flags in the [catalog](../models) or on [pc.0g.ai](https://pc.0g.ai). Sending `tools` to a model that doesn't support it returns `400 Bad Request`.
+:::
+
+The response shape (`tool_calls` in the assistant message, `tool` role for results) matches OpenAI exactly.
+
+## JSON Mode
+
+For models that support structured output:
+
+```json
+{
+  "model": "zai-org/GLM-5-FP8",
+  "messages": [
+    {"role": "system", "content": "Respond with JSON only."},
+    {"role": "user", "content": "List three colors and their hex codes."}
+  ],
+  "response_format": {"type": "json_object"}
+}
+```
+
+As with tool calling, check capability flags before using.
+
+## Response shape
+
+Responses are OpenAI-compatible (`choices[]`, `usage`, `model`, `id`, `object`, `created`). The Router adds two Router-specific additions on top:
+
+### `x_0g_trace` (always present)
+
+Every Router response carries an `x_0g_trace` object with metadata about the request's execution:
+
+```json
+"x_0g_trace": {
+  "request_id": "0852f405-6c56-40c2-a800-e6fd70785065",
+  "provider": "0xd9966e13a6026Fcca4b13E7ff95c94DE268C471C",
+  "billing": {
+    "input_cost":  "19000000000000",
+    "output_cost": "1916800000000000",
+    "total_cost":  "1935800000000000"
+  }
+}
+```
+
+| Field | Description |
+| --- | --- |
+| `request_id` | Unique ID for this request. Quote it in any support ticket or bug report. |
+| `provider` | On-chain address of the provider that served the request |
+| `billing.input_cost` / `output_cost` / `total_cost` | Exact cost in **neuron** for this specific request |
+| `tee_verified` | Present only when `verify_tee: true` was set — see [Verifiable Execution](./verifiable-execution) |
+
+This means you don't need to compute costs yourself — the Router tells you exactly what was charged. Handy for per-request logging and client-side budget tracking.
+
+### `reasoning_content` (thinking models)
+
+For models with thinking support (e.g. `zai-org/GLM-5-FP8`), the Router returns the reasoning trace alongside the final answer. It appears in two equivalent places:
+
+```json
+"choices": [{
+  "message": {
+    "role": "assistant",
+    "content": "{ \"colors\": [ ... ] }",
+    "reasoning_content": "The user wants a JSON response...",
+    "provider_specific_fields": {
+      "reasoning_content": "The user wants a JSON response..."
+    }
+  }
+}]
+```
+
+Both fields contain the same text; most OpenAI SDKs surface `reasoning_content` directly on the message. You can ignore it for production output, log it for debugging, or display it to the user as "thinking".
+
+:::tip Disable thinking for GLM-5
+Thinking is on by default for GLM-5. If you don't want it (saves tokens and latency), pass `chat_template_kwargs: {"enable_thinking": false}` in the request body — GLM-5 advertises this in its `supported_parameters`.
+:::
+
+## Related
+
+- [**Routing**](../routing) — choose your provider
+- [**Errors**](../errors) — response codes and error shapes

--- a/docs/developer-hub/building-on-0g/compute-network/router/features/image-generation.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/features/image-generation.md
@@ -157,9 +157,8 @@ The same optional top-level fields as chat completions, stripped before forwardi
 
 Image generation is charged per image at rates declared by the model (see `pricing.image` in the [catalog](../models)). Billing is tied to the provider's execution, not to your client holding the connection:
 
-- **Submission starts the clock.** Once the provider accepts the job, generation begins and tokens start to be consumed.
+- **Submission starts the clock.** Once the provider accepts the job, generation begins.
 - **Abandoning a poll does not cancel the job.** If you close the HTTP connection, stop polling, or kill your process after submitting, the provider still runs the job to completion and you are still billed.
-- **Failed jobs** (provider-side error) are not billed.
 
 ## Related
 

--- a/docs/developer-hub/building-on-0g/compute-network/router/features/image-generation.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/features/image-generation.md
@@ -105,7 +105,7 @@ The Router responds immediately with a job handle:
 
 ```json
 {
-  "job_id": "job_abc123",
+  "jobId": "5b595c31955d4be2923f5070705cced4",
   "status": "pending",
   "provider_address": "0xE29a72..."
 }
@@ -118,30 +118,31 @@ The Router responds immediately with a job handle:
 **`GET /v1/async/jobs/{jobId}?provider_address={addr}`**
 
 ```bash
-curl "https://router-api.0g.ai/v1/async/jobs/job_abc123?provider_address=0xE29a72..." \
+curl "https://router-api.0g.ai/v1/async/jobs/5b595c31955d4be2923f5070705cced4?provider_address=0xE29a72..." \
   -H "Authorization: Bearer sk-YOUR_API_KEY"
 ```
 
-While running:
-
-```json
-{ "job_id": "job_abc123", "status": "running", "provider_address": "0xE29a72..." }
-```
-
-When complete, the response adds the standard OpenAI `data` array:
+While the job is running, `status` is `"pending"` (or `"running"`). When finished, `status: "completed"` appears with the result payload and an injected `x_0g_trace`:
 
 ```json
 {
-  "job_id": "job_abc123",
   "status": "completed",
-  "provider_address": "0xE29a72...",
-  "data": [
-    { "b64_json": "iVBORw0KGgoAAAANSUhEUg..." }
-  ]
+  "createdAt": "2026-04-24T09:44:57.804Z",
+  "data": {
+    "created": 1777023898,
+    "data": [
+      { "b64_json": "iVBORw0KGgoAAAANSUhEUg..." }
+    ]
+  },
+  "x_0g_trace": { "request_id": "...", "provider": "0x...", "billing": { "input_cost": "...", "output_cost": "...", "total_cost": "..." } }
 }
 ```
 
-Polling every 2–3 seconds is typical.
+The image array lives at `data.data[]` — the outer `data` is a wrapper object the provider returns around the OpenAI-style result, not the OpenAI array itself.
+
+:::tip Use the `Retry-After` header for polling cadence
+Both submit and poll responses forward a `Retry-After` header (in seconds) when the provider sends one — use that value to decide when to poll again, since it reflects the provider's current queue. Fall back to a fixed 2–3 second interval only if the header is missing.
+:::
 
 ## 0G Router Extensions
 
@@ -154,7 +155,11 @@ The same optional top-level fields as chat completions, stripped before forwardi
 
 ## Billing
 
-Image generation is charged per image at rates declared by the model (see `pricing.image` in the [catalog](../models)). You're only charged when the job completes successfully — failed or cancelled jobs are not billed.
+Image generation is charged per image at rates declared by the model (see `pricing.image` in the [catalog](../models)). Billing is tied to the provider's execution, not to your client holding the connection:
+
+- **Submission starts the clock.** Once the provider accepts the job, generation begins and tokens start to be consumed.
+- **Abandoning a poll does not cancel the job.** If you close the HTTP connection, stop polling, or kill your process after submitting, the provider still runs the job to completion and you are still billed.
+- **Failed jobs** (provider-side error) are not billed.
 
 ## Related
 

--- a/docs/developer-hub/building-on-0g/compute-network/router/features/image-generation.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/features/image-generation.md
@@ -1,0 +1,163 @@
+---
+id: image-generation
+title: Image Generation
+sidebar_position: 3
+description: "Generate images on 0G Compute via synchronous (OpenAI-compatible) or asynchronous submit-and-poll endpoints."
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Image Generation
+
+The Router exposes two paths for image generation:
+
+- **Synchronous** — drop-in OpenAI-compatible endpoint (`POST /v1/images/generations`). Returns the image in the same request. Best when you're using the OpenAI SDK directly or have short/fast models.
+- **Asynchronous (recommended for production)** — submit a job and poll (`POST /v1/async/images/generations` + `GET /v1/async/jobs/{jobId}`). Avoids long-held HTTP connections. Best for slow models, batch workloads, serverless, or browser reliability.
+
+Both paths accept the same request shape and produce the same final output.
+
+:::caution `response_format: "b64_json"` is currently required
+Always send `"response_format": "b64_json"`. Base64 is the only format supported end-to-end right now; URL-based responses will be enabled in a future release. This applies to **both** sync and async paths.
+:::
+
+## Synchronous — OpenAI-compatible
+
+**`POST /v1/images/generations`**
+
+Fully compatible with the [OpenAI Images API](https://platform.openai.com/docs/api-reference/images/create) — any OpenAI client library works unchanged once you switch the base URL.
+
+<Tabs>
+<TabItem value="curl" label="cURL" default>
+
+```bash
+curl https://router-api.0g.ai/v1/images/generations \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer sk-YOUR_API_KEY" \
+  -d '{
+    "model": "z-image",
+    "prompt": "A serene mountain landscape at sunset",
+    "n": 1,
+    "size": "1024x1024",
+    "response_format": "b64_json"
+  }'
+```
+
+</TabItem>
+<TabItem value="python" label="Python (OpenAI SDK)">
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://router-api.0g.ai/v1",
+    api_key="sk-YOUR_API_KEY",
+)
+
+result = client.images.generate(
+    model="z-image",
+    prompt="A serene mountain landscape at sunset",
+    n=1,
+    size="1024x1024",
+    response_format="b64_json",
+)
+
+print(result.data[0].b64_json[:80], "...")
+```
+
+</TabItem>
+</Tabs>
+
+Returns the standard OpenAI image response: a `data` array with `b64_json` entries. Decode on the client to render.
+
+### Request fields
+
+| Field             | Required | Description                                                    |
+| ----------------- | -------- | -------------------------------------------------------------- |
+| `model`           | ✓        | Image model ID from [`/v1/models`](../models)                 |
+| `prompt`          | ✓        | Text description of the desired image                          |
+| `response_format` | ✓        | Must be `"b64_json"` today; `"url"` support is planned         |
+| `n`               |          | Number of images to generate                                   |
+| `size`            |          | e.g. `"1024x1024"` — check the model for supported sizes       |
+
+## Asynchronous (recommended for production)
+
+Image generation can take tens of seconds. Holding an HTTP connection open that long is fragile — short-timeout clients, browsers, and serverless functions will drop it. The async path solves this: submit once, poll until ready.
+
+### 1. Submit a job
+
+**`POST /v1/async/images/generations`** — same body as the synchronous endpoint.
+
+```bash
+curl https://router-api.0g.ai/v1/async/images/generations \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer sk-YOUR_API_KEY" \
+  -d '{
+    "model": "z-image",
+    "prompt": "A serene mountain landscape at sunset",
+    "n": 1,
+    "size": "1024x1024",
+    "response_format": "b64_json"
+  }'
+```
+
+The Router responds immediately with a job handle:
+
+```json
+{
+  "job_id": "job_abc123",
+  "status": "pending",
+  "provider_address": "0xE29a72..."
+}
+```
+
+`provider_address` identifies which provider is handling your job. You'll pass it back when polling — async jobs are pinned to their provider.
+
+### 2. Poll for the result
+
+**`GET /v1/async/jobs/{jobId}?provider_address={addr}`**
+
+```bash
+curl "https://router-api.0g.ai/v1/async/jobs/job_abc123?provider_address=0xE29a72..." \
+  -H "Authorization: Bearer sk-YOUR_API_KEY"
+```
+
+While running:
+
+```json
+{ "job_id": "job_abc123", "status": "running", "provider_address": "0xE29a72..." }
+```
+
+When complete, the response adds the standard OpenAI `data` array:
+
+```json
+{
+  "job_id": "job_abc123",
+  "status": "completed",
+  "provider_address": "0xE29a72...",
+  "data": [
+    { "b64_json": "iVBORw0KGgoAAAANSUhEUg..." }
+  ]
+}
+```
+
+Polling every 2–3 seconds is typical.
+
+## 0G Router Extensions
+
+The same optional top-level fields as chat completions, stripped before forwarding to the provider (applies to both sync and async paths):
+
+| Field        | Type    | Description                                                                          |
+| ------------ | ------- | ------------------------------------------------------------------------------------ |
+| `provider`   | object  | Control provider routing — see [Routing](../routing)                                 |
+| `verify_tee` | boolean | Ask the Router to synchronously verify the provider's TEE signature — see [Verifiable Execution](./verifiable-execution) |
+
+## Billing
+
+Image generation is charged per image at rates declared by the model (see `pricing.image` in the [catalog](../models)). You're only charged when the job completes successfully — failed or cancelled jobs are not billed.
+
+## Related
+
+- [**Models**](../models) — browse available image models and sizes
+- [**Routing**](../routing)
+- [**Verifiable Execution**](./verifiable-execution)

--- a/docs/developer-hub/building-on-0g/compute-network/router/features/verifiable-execution.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/features/verifiable-execution.md
@@ -1,0 +1,142 @@
+---
+id: verifiable-execution
+title: Verifiable Execution (verify_tee)
+sidebar_label: Verifiable Execution
+sidebar_position: 5
+description: "Opt-in TEE signature verification for Router responses. Ask the Router to synchronously verify that a response came from an attested TEE provider."
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Verifiable Execution
+
+Every 0G Compute provider runs inside a **Trusted Execution Environment (TEE)** and cryptographically signs its responses. The Router can verify that signature synchronously on your behalf and report the result back in the response metadata.
+
+## Opt in with `verify_tee`
+
+Add `verify_tee: true` to any inference request, and the Router will verify the provider's TEE signature before returning the response. The verification result appears in the response trace.
+
+<Tabs>
+<TabItem value="json" label="JSON body" default>
+
+```bash
+curl https://router-api.0g.ai/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer sk-YOUR_API_KEY" \
+  -d '{
+    "model": "zai-org/GLM-5-FP8",
+    "messages": [{"role": "user", "content": "Hello"}],
+    "verify_tee": true
+  }'
+```
+
+</TabItem>
+<TabItem value="query" label="Query parameter">
+
+For endpoints that use `multipart/form-data` (like `/v1/audio/transcriptions` or image edits), pass `verify_tee` as a query parameter instead:
+
+```bash
+curl "https://router-api.0g.ai/v1/audio/transcriptions?verify_tee=true" \
+  -H "Authorization: Bearer sk-YOUR_API_KEY" \
+  -F "file=@recording.mp3" \
+  -F "model=openai/whisper-large-v3"
+```
+
+</TabItem>
+</Tabs>
+
+`verify_tee` is a 0G Router extension — it's stripped from the request before being forwarded to the provider, so it doesn't interfere with the OpenAI-compatible schema.
+
+## Reading the result
+
+When `verify_tee` is set, the Router adds a `tee_verified` field to the response's `x_0g_trace` metadata block (which is present on every Router response — see [Response shape](./chat-completions#response-shape)):
+
+```json
+"x_0g_trace": {
+  "request_id": "0852f405-6c56-40c2-a800-e6fd70785065",
+  "provider": "0xd9966e13a6026Fcca4b13E7ff95c94DE268C471C",
+  "billing": { "input_cost": "...", "output_cost": "...", "total_cost": "..." },
+  "tee_verified": true
+}
+```
+
+| `tee_verified` | Meaning |
+| --- | --- |
+| `true` | The provider's TEE signature was validated successfully |
+| `false` | A signature was present but did not verify — treat the response as untrusted |
+| `null` / absent | Verification was not requested for this response |
+
+## When to use it
+
+- **Most chat-like applications** don't need per-request verification — the provider is already inside a TEE, and the network tolerates a small rate of signed-but-unverified responses.
+- **Audit logs, high-trust pipelines, and research workloads** benefit from setting `verify_tee: true` so that every response carries a validated attestation flag alongside it.
+- The pc.0g.ai UI enables `verify_tee` by default for playground requests; feel free to mirror that behaviour in your own clients.
+
+## Trust model
+
+`verify_tee: true` asks the **Router** to fetch the provider's TEE signature, look up the signer address on-chain, and verify the signature on your behalf. The Router returns a single boolean (`tee_verified`) summarising that check.
+
+In other words, `tee_verified: true` in the response says *"the Router says it verified the signature."* It does **not** carry the raw signature back to you — you still have to trust the Router to have done the check honestly.
+
+If that level of trust is acceptable for your application, stop here: set `verify_tee: true` and read the flag.
+
+If you need an independent guarantee, **all the inputs the Router uses are public**, and you can reproduce the verification yourself. See the next section.
+
+## Independent verification (advanced)
+
+You don't have to trust the Router's `tee_verified` flag — the underlying inputs are all public, and the `@0glabs/0g-serving-broker` SDK ships a one-shot helper that does the whole verification for you.
+
+### With the SDK (recommended)
+
+The `chatID` required for verification comes from the **`ZG-Res-Key` response header** (the `id` field in the JSON body is a fallback when the header is absent). That means you need access to the raw HTTP response headers — `fetch` works directly; for OpenAI SDKs use their "raw response" / "with-response" helper.
+
+```typescript
+import { ethers } from "ethers";
+import { createZGComputeNetworkBroker } from "@0glabs/0g-serving-broker";
+
+// Any wallet works — processResponse only reads the chain and calls the provider's public signature endpoint.
+const rpc = new ethers.JsonRpcProvider("https://evmrpc.0g.ai");
+const wallet = ethers.Wallet.createRandom().connect(rpc);
+const broker = await createZGComputeNetworkBroker(wallet);
+
+// 1. Make the request so you can read headers
+const response = await fetch("https://router-api.0g.ai/v1/chat/completions", {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    "Authorization": "Bearer sk-YOUR_API_KEY",
+  },
+  body: JSON.stringify({ model: "zai-org/GLM-5-FP8", messages: [...] }),
+});
+const data = await response.json();
+
+// 2. Pull the two inputs processResponse needs
+const providerAddress = data.x_0g_trace.provider;
+const chatID          = response.headers.get("ZG-Res-Key") ?? data.id;
+
+// 3. Verify independently — SDK reads the chain + calls the provider, not the Router
+const isValid = await broker.inference.processResponse(providerAddress, chatID);
+// true  → independently verified
+// false → verification failed (treat response as untrusted)
+// null  → provider has no verifiable TEE service (nothing to check)
+```
+
+Under the hood the SDK reads the provider's on-chain service record, fetches the signature from the provider, and verifies it against the TEE signer — the same work the Router does internally, but running on your side so you don't have to trust the Router's answer.
+
+### Without the SDK
+
+If you prefer to verify from scratch (e.g. from a language without the 0G SDK), the four steps you'd reproduce are:
+
+1. Read the provider's service record from the on-chain `Service` contract using the `provider` address. The record gives you `url`, `teeSignerAddress`, and `verifiability`. (If `additionalInfo.targetSeparated` is true, use `additionalInfo.targetTeeAddress` as the signer instead.)
+2. `GET {url}/v1/proxy/signature/{chatID}?model={model}` — returns `{text, signature}`.
+3. Verify the signature as EIP-191 `personal_sign` against `teeSignerAddress`. Any standard Ethereum library works.
+4. Confirm the signed `text` matches the response content you received from the Router.
+
+All four steps pass → end-to-end cryptographic proof, no trust in the Router required.
+
+## Related
+
+- [**Principles: Verifiable Execution**](../principles#4-verifiable-execution) — the "why" behind this feature
+- [**Chat Completions**](./chat-completions#response-shape) — structure of the `x_0g_trace` block
+- [**Provider Routing**](../routing) — pin to a specific attested provider with `provider.address`

--- a/docs/developer-hub/building-on-0g/compute-network/router/models.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/models.md
@@ -1,0 +1,62 @@
+---
+id: models
+title: Models
+sidebar_position: 4
+description: "Browse the live model catalog — pricing, context window, capabilities, and provider count."
+---
+
+# Models
+
+The model catalog is served live by the Router. You can browse it two ways:
+
+- **Web UI** — **[pc.0g.ai](https://pc.0g.ai)** shows every model with current pricing, the number of healthy providers, and capability badges (streaming, tool calling, vision, etc.).
+- **API** — `GET /v1/models` returns the same data in OpenAI's list format. No authentication required.
+
+## Listing Models
+
+```bash
+curl https://router-api.0g.ai/v1/models
+```
+
+```json
+{
+  "object": "list",
+  "data": [
+    {
+      "id": "zai-org/GLM-5-FP8",
+      "object": "model",
+      "owned_by": "0G Foundation",
+      "name": "zai-org/GLM-5-FP8",
+      "context_length": 131072,
+      "pricing": {
+        "prompt": "100000000000",
+        "completion": "320000000000"
+      },
+      "provider_count": 3
+    }
+  ]
+}
+```
+
+Prices are in **neuron per token** (1e18 neuron = 1 0G). Multiply by `input_tokens` / `output_tokens` to estimate cost.
+
+## Capability Flags
+
+Not every model supports every feature. Before relying on **tool calling**, **vision input**, or **JSON mode**, check the model's entry in the Web UI or in the `/v1/models` response — capability flags are shown on each model card and in the API payload.
+
+If you send a `tools` field to a model that doesn't support it, the Router returns `400 Bad Request` rather than silently dropping the parameter.
+
+## Listing Providers for a Model
+
+```bash
+curl "https://router-api.0g.ai/v1/providers?model=zai-org/GLM-5-FP8"
+```
+
+Returns every TEE-acknowledged provider serving that model, with on-chain address, observed latency, and TEE attestation info. Use these addresses with the [`provider.address` field](./routing) if you want deterministic routing.
+
+Query parameters:
+
+| Field          | Description                                                        |
+| -------------- | ------------------------------------------------------------------ |
+| `model`        | Filter to providers serving a specific model ID                    |
+| `service_type` | Filter by service type (e.g. `chatbot`, `text-to-image`, `speech-to-text`) |

--- a/docs/developer-hub/building-on-0g/compute-network/router/overview.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/overview.md
@@ -1,0 +1,67 @@
+---
+id: overview
+title: Overview
+sidebar_position: 1
+description: "A single OpenAI-compatible endpoint for every model on the 0G Compute Network. No SDK, no wallet keys — just an API key."
+---
+
+# 0G Compute Router
+
+The **0G Compute Router** is an API gateway that sits in front of the entire 0G Compute Network. One endpoint, one API key, every model.
+
+It handles provider discovery, on-chain billing, authentication, and failover automatically — so you use 0G's decentralized inference with the same code you'd write for OpenAI or Anthropic.
+
+## When to Use the Router
+
+|                     | **Router**                          | **[Direct](../direct)**        |
+| ------------------- | ----------------------------------- | ---------------------------------- |
+| Setup               | Get an API key                      | Install SDK, manage wallet keys    |
+| Provider management | Automatic routing + failover        | Manual selection & funding         |
+| Billing             | Single unified on-chain balance     | Per-provider sub-accounts          |
+| API shape           | OpenAI / Anthropic compatible       | Custom SDK calls                   |
+| Best for            | Server-side apps, agents, prototypes| Browser dApps, direct chain access |
+
+Pick the Router when you want the simplest integration path. Pick Direct when you need per-provider control or wallet-signed requests in the browser.
+
+## 60-Second Tour
+
+<div className="feature-grid">
+
+**[Quickstart →](./quickstart)**
+Connect wallet, deposit, create an API key, send your first request — in four steps.
+
+**[Chat Completions →](./features/chat-completions)**
+OpenAI-compatible `/v1/chat/completions` with streaming, tool calling, and reasoning tokens.
+
+**[Provider Routing →](./routing)**
+Route by lowest latency, lowest price, or pin to a specific on-chain provider.
+
+**[Authentication →](./authentication)**
+API keys with three permission tiers.
+
+**[Models →](./models)**
+Browse the live catalog. Each model has pricing, context window, and capability flags.
+
+**[Deposits & Billing →](./account/deposits)**
+Deposit 0G tokens, consume on-chain, settle periodically. No subscriptions.
+
+</div>
+
+## Base URLs
+
+Both networks share the same Web UI at **[pc.0g.ai](https://pc.0g.ai)** — switch networks from your wallet, and the dashboard flips between mainnet and testnet automatically. Only the API endpoint you point your code at differs.
+
+| Network     | API Endpoint                                              |
+| ----------- | --------------------------------------------------------- |
+| **Mainnet** | `https://router-api.0g.ai/v1`                             |
+| **Testnet** | `https://router-api-testnet.integratenetwork.work/v1`     |
+
+:::tip OpenAI SDK drop-in
+Any tool that speaks the OpenAI API works with 0G Router — change `base_url` and `api_key`, nothing else.
+:::
+
+:::note Migrating from compute-marketplace.0g.ai?
+If you previously deposited on **[compute-marketplace.0g.ai](https://compute-marketplace.0g.ai)**, those funds live in **per-provider sub-accounts** under the [Direct](../direct) flow. They do **not** appear in the Router balance on pc.0g.ai — the two systems use different contracts and different accounting.
+
+To see and use those old funds on pc.0g.ai, switch to **Advanced** mode using the toggle in the top-right. Advanced mode is the same Direct flow, just embedded in the new UI. See [Router vs Advanced Mode](./comparison#pc0gai-router-vs-advanced-mode).
+:::

--- a/docs/developer-hub/building-on-0g/compute-network/router/overview.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/overview.md
@@ -49,12 +49,12 @@ Deposit 0G tokens, consume on-chain, settle periodically. No subscriptions.
 
 ## Base URLs
 
-Both networks share the same Web UI at **[pc.0g.ai](https://pc.0g.ai)** — switch networks from your wallet, and the dashboard flips between mainnet and testnet automatically. Only the API endpoint you point your code at differs.
+Mainnet and testnet are fully separate environments — different Web UI, different API endpoint, different on-chain balances and API keys. Pick the one that matches the network your wallet is on.
 
-| Network     | API Endpoint                                              |
-| ----------- | --------------------------------------------------------- |
-| **Mainnet** | `https://router-api.0g.ai/v1`                             |
-| **Testnet** | `https://router-api-testnet.integratenetwork.work/v1`     |
+| Network     | Web UI                                              | API Endpoint                                              |
+| ----------- | --------------------------------------------------- | --------------------------------------------------------- |
+| **Mainnet** | [pc.0g.ai](https://pc.0g.ai)                        | `https://router-api.0g.ai/v1`                             |
+| **Testnet** | [pc.testnet.0g.ai](https://pc.testnet.0g.ai)        | `https://router-api-testnet.integratenetwork.work/v1`     |
 
 :::tip OpenAI SDK drop-in
 Any tool that speaks the OpenAI API works with 0G Router — change `base_url` and `api_key`, nothing else.

--- a/docs/developer-hub/building-on-0g/compute-network/router/principles.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/principles.md
@@ -1,0 +1,46 @@
+---
+id: principles
+title: Principles
+sidebar_position: 3
+description: "The design choices behind the Router — API compatibility, on-chain settlement, failover, and verifiable execution."
+---
+
+# Principles
+
+The Router exists to make 0G's decentralized compute network usable with the same code you already have. Four design choices shape how it works.
+
+## 1. Drop-in Compatibility
+
+The Router speaks the **OpenAI API** (`/v1/chat/completions`, `/v1/images/generations`, `/v1/audio/transcriptions`, …). Same routes, same fields, same SSE format.
+
+Any SDK, agent framework, or tool that targets these APIs works without code changes — point it at `https://router-api.0g.ai/v1` and supply your Router API key.
+
+The goal is zero switching cost. If we add a feature that OpenAI doesn't have (like provider pinning), it lives in an optional top-level field that is stripped before the request reaches the underlying provider. Your existing requests keep working.
+
+## 2. On-Chain Billing, No Subscriptions
+
+There is no monthly plan. You deposit 0G tokens to a payment contract, and each request debits the exact cost based on per-model token prices. Remaining balance is always visible on-chain.
+
+```
+total_cost = (input_tokens × prompt_price) + (output_tokens × completion_price)
+```
+
+Settlement to individual providers happens periodically in the background — you only see a single unified balance. Details: [Deposits & Billing](./account/deposits).
+
+## 3. Failover by Default
+
+Each model is served by one or more independent providers. The Router health-checks them continuously and distributes requests round-robin across the healthy set. If a request fails, the Router retries on the next healthy provider before returning an error to you.
+
+You can override this — [Provider Routing](./routing) lets you sort by `latency` / `price` or pin to a specific provider address — but the default is "just work."
+
+## 4. Verifiable Execution
+
+Every provider on the network runs inside a **Trusted Execution Environment (TEE)** and attests to the exact model it's serving. The Router exposes provider addresses and attestation metadata so you can verify, out-of-band, that your request was handled by a model you trust.
+
+This is the reason to use 0G over a centralized endpoint: you get OpenAI-style ergonomics **and** cryptographic proof that the model wasn't silently swapped.
+
+## What the Router Does Not Do
+
+- **No prompt storage.** The Router does not persist request or response bodies. Only billing metadata (token counts, model, provider, timestamp) is stored.
+- **Provider isolation via TEE.** Every provider runs inside a Trusted Execution Environment, which isolates the serving process so it cannot access inference traffic outside the attested request/response path.
+- **No synthetic responses.** The Router never generates content itself. If no provider can serve the request, you get a `503` — not a fallback LLM.

--- a/docs/developer-hub/building-on-0g/compute-network/router/quickstart.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/quickstart.md
@@ -14,7 +14,7 @@ Four steps. Five minutes.
 
 ## 1. Connect Your Wallet
 
-Visit **[pc.0g.ai](https://pc.0g.ai)** and connect a wallet. MetaMask, WalletConnect, and email (via Privy) are all supported.
+Visit **[pc.0g.ai](https://pc.0g.ai)** and connect a wallet. MetaMask and WalletConnect work directly; you can also sign in with Google, X/Twitter, Discord, or TikTok via Privy, which provisions an embedded wallet for you.
 
 ## 2. Deposit Funds
 

--- a/docs/developer-hub/building-on-0g/compute-network/router/quickstart.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/quickstart.md
@@ -1,0 +1,95 @@
+---
+id: quickstart
+title: Quickstart
+sidebar_position: 2
+description: "Four steps from zero to your first inference request."
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Quickstart
+
+Four steps. Five minutes.
+
+## 1. Connect Your Wallet
+
+Visit **[pc.0g.ai](https://pc.0g.ai)** and connect a wallet. MetaMask, WalletConnect, and email (via Privy) are all supported.
+
+## 2. Deposit Funds
+
+Deposit 0G tokens to the Router's on-chain payment contract. Your balance lives on-chain and is debited per request.
+
+See [Deposits & Billing](./account/deposits) for how costs are calculated and how to check your balance.
+
+## 3. Create an API Key
+
+In **Dashboard → API Keys**, create a key with the `inference` permission. You'll get a secret starting with `sk-`.
+
+Store it somewhere safe — the Router never shows it again.
+
+## 4. Send Your First Request
+
+<Tabs>
+<TabItem value="curl" label="cURL" default>
+
+```bash
+curl https://router-api.0g.ai/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer sk-YOUR_API_KEY" \
+  -d '{
+    "model": "zai-org/GLM-5-FP8",
+    "messages": [
+      {"role": "user", "content": "Hello!"}
+    ]
+  }'
+```
+
+</TabItem>
+<TabItem value="python" label="Python (OpenAI SDK)">
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://router-api.0g.ai/v1",
+    api_key="sk-YOUR_API_KEY",
+)
+
+response = client.chat.completions.create(
+    model="zai-org/GLM-5-FP8",
+    messages=[{"role": "user", "content": "Hello!"}],
+)
+
+print(response.choices[0].message.content)
+```
+
+</TabItem>
+<TabItem value="js" label="JavaScript (OpenAI SDK)">
+
+```javascript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "https://router-api.0g.ai/v1",
+  apiKey: "sk-YOUR_API_KEY",
+});
+
+const response = await client.chat.completions.create({
+  model: "zai-org/GLM-5-FP8",
+  messages: [{ role: "user", content: "Hello!" }],
+});
+
+console.log(response.choices[0].message.content);
+```
+
+</TabItem>
+</Tabs>
+
+That's it. You're talking to a decentralized TEE-backed provider through an OpenAI-compatible API.
+
+## Next Steps
+
+- **[Chat Completions](./features/chat-completions)** — streaming, tool calling, system prompts
+- **[Provider Routing](./routing)** — route by latency, price, or specific provider
+- **[Models](./models)** — browse the catalog with live pricing

--- a/docs/developer-hub/building-on-0g/compute-network/router/rate-limits.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/rate-limits.md
@@ -34,7 +34,7 @@ Content-Type: application/json
   "error": {
     "message": "Rate limit exceeded. Please try again later.",
     "type": "rate_limit_error",
-    "code": "too_many_requests"
+    "code": "rate_limit_exceeded"
   }
 }
 ```

--- a/docs/developer-hub/building-on-0g/compute-network/router/rate-limits.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/rate-limits.md
@@ -2,27 +2,33 @@
 id: rate-limits
 title: Rate Limits
 sidebar_position: 9
-description: "How the Router throttles requests under load, what you see on the wire, and how to handle 429 responses."
+description: "How the Router throttles requests, what headers you'll see, and how to handle 429 responses."
 ---
 
 # Rate Limits
 
-The Router dynamically throttles requests based on current network load. When demand spikes or a particular model's providers are saturated, you may be rate limited for a short period.
+The Router applies per-account request limits to keep the network responsive. The exact thresholds depend on your account state and may evolve as we tune them — this page documents how to **observe and react to** the limit, not the specific numbers.
 
-## What you'll see
+## Response headers
 
-When the Router accepts your request but cannot yet dispatch it to a provider, the HTTP connection stays open and you'll keep receiving keep-alive traffic until the request goes through or times out:
+Every inference response includes rate-limit headers (OpenAI-compatible) so you can back off proactively without waiting for a `429`:
 
-- **Non-streaming requests** — the server periodically sends empty lines while waiting
-- **Streaming (SSE) requests** — the server sends SSE keep-alive comments (`: keep-alive`) every few seconds
+```
+X-RateLimit-Limit-Requests: <your current per-minute limit>
+X-RateLimit-Remaining-Requests: <how many you have left in this window>
+X-RateLimit-Reset-Requests: <ISO-8601 timestamp when the window resets>
+```
 
-Neither affects JSON body parsing. Standard OpenAI client libraries and `curl` handle both correctly out of the box. If you're parsing the HTTP response yourself, skip empty lines / comment frames that arrive before the real payload.
+Some accounts also receive daily-window headers:
 
-If the Router cannot serve your request within **10 minutes**, it closes the connection.
+```
+X-RateLimit-Limit-Day: <daily quota>
+X-RateLimit-Remaining-Day: <left today>
+```
 
 ## 429 Too Many Requests
 
-When the Router decides to reject rather than wait, it returns `429 Too Many Requests` with a `Retry-After` header (seconds):
+When you exceed the limit, the Router returns `429` immediately with a `Retry-After` header (seconds):
 
 ```
 HTTP/1.1 429 Too Many Requests
@@ -33,7 +39,7 @@ Content-Type: application/json
 ```json
 {
   "error": {
-    "message": "Rate limit exceeded",
+    "message": "Rate limit exceeded. Please try again later.",
     "type": "rate_limit_error",
     "code": "too_many_requests"
   }
@@ -48,5 +54,5 @@ Content-Type: application/json
 - [**Deposits & Billing**](./account/deposits)
 
 :::info Coming soon
-Per-API-key throughput controls — explicit **RPM** (requests per minute) and **TPM** (tokens per minute) budgets set in the dashboard — are on the roadmap. Today throttling is purely load-adaptive.
+Per-API-key throughput controls — explicit **RPM** (requests per minute) and **TPM** (tokens per minute) budgets settable in the dashboard — are on the roadmap.
 :::

--- a/docs/developer-hub/building-on-0g/compute-network/router/rate-limits.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/rate-limits.md
@@ -1,0 +1,52 @@
+---
+id: rate-limits
+title: Rate Limits
+sidebar_position: 9
+description: "How the Router throttles requests under load, what you see on the wire, and how to handle 429 responses."
+---
+
+# Rate Limits
+
+The Router dynamically throttles requests based on current network load. When demand spikes or a particular model's providers are saturated, you may be rate limited for a short period.
+
+## What you'll see
+
+When the Router accepts your request but cannot yet dispatch it to a provider, the HTTP connection stays open and you'll keep receiving keep-alive traffic until the request goes through or times out:
+
+- **Non-streaming requests** — the server periodically sends empty lines while waiting
+- **Streaming (SSE) requests** — the server sends SSE keep-alive comments (`: keep-alive`) every few seconds
+
+Neither affects JSON body parsing. Standard OpenAI client libraries and `curl` handle both correctly out of the box. If you're parsing the HTTP response yourself, skip empty lines / comment frames that arrive before the real payload.
+
+If the Router cannot serve your request within **10 minutes**, it closes the connection.
+
+## 429 Too Many Requests
+
+When the Router decides to reject rather than wait, it returns `429 Too Many Requests` with a `Retry-After` header (seconds):
+
+```
+HTTP/1.1 429 Too Many Requests
+Retry-After: 15
+Content-Type: application/json
+```
+
+```json
+{
+  "error": {
+    "message": "Rate limit exceeded",
+    "type": "rate_limit_error",
+    "code": "too_many_requests"
+  }
+}
+```
+
+**Honor `Retry-After`.** Don't retry in a tight loop — the Router will keep returning `429` and your real requests will be delayed.
+
+## Related
+
+- [**Errors**](./errors)
+- [**Deposits & Billing**](./account/deposits)
+
+:::info Coming soon
+Per-API-key throughput controls — explicit **RPM** (requests per minute) and **TPM** (tokens per minute) budgets set in the dashboard — are on the roadmap. Today throttling is purely load-adaptive.
+:::

--- a/docs/developer-hub/building-on-0g/compute-network/router/rate-limits.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/rate-limits.md
@@ -13,24 +13,17 @@ The Router applies per-account request limits to keep the network responsive. Th
 
 Every inference response includes rate-limit headers (OpenAI-compatible) so you can back off proactively without waiting for a `429`:
 
-```
+```http
 X-RateLimit-Limit-Requests: <your current per-minute limit>
 X-RateLimit-Remaining-Requests: <how many you have left in this window>
 X-RateLimit-Reset-Requests: <ISO-8601 timestamp when the window resets>
-```
-
-Some accounts also receive daily-window headers:
-
-```
-X-RateLimit-Limit-Day: <daily quota>
-X-RateLimit-Remaining-Day: <left today>
 ```
 
 ## 429 Too Many Requests
 
 When you exceed the limit, the Router returns `429` immediately with a `Retry-After` header (seconds):
 
-```
+```http
 HTTP/1.1 429 Too Many Requests
 Retry-After: 15
 Content-Type: application/json

--- a/docs/developer-hub/building-on-0g/compute-network/router/routing.md
+++ b/docs/developer-hub/building-on-0g/compute-network/router/routing.md
@@ -1,0 +1,90 @@
+---
+id: routing
+title: Provider Routing
+sidebar_position: 5
+description: "Control which provider serves your request — by latency, price, or specific on-chain address."
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Provider Routing
+
+By default, the Router distributes requests across healthy providers using round-robin with automatic failover. The `provider` field lets you override this when you need specific behavior.
+
+## Default Behavior
+
+If you send no `provider` field, the Router:
+
+1. Picks a healthy provider for the requested model
+2. Retries on the next healthy provider if the first returns an error
+3. Returns the response — or a `503` if every provider failed
+
+This is the recommended path for most applications.
+
+## Routing Strategies
+
+<Tabs>
+<TabItem value="latency" label="Lowest Latency" default>
+
+```json
+{
+  "model": "zai-org/GLM-5-FP8",
+  "messages": [{"role": "user", "content": "Hello"}],
+  "provider": {
+    "sort": "latency"
+  }
+}
+```
+
+Routes to the provider with the lowest recently-observed latency for this model.
+
+</TabItem>
+<TabItem value="price" label="Lowest Price">
+
+```json
+{
+  "model": "zai-org/GLM-5-FP8",
+  "messages": [{"role": "user", "content": "Hello"}],
+  "provider": {
+    "sort": "price"
+  }
+}
+```
+
+Routes to the cheapest provider currently serving this model.
+
+</TabItem>
+<TabItem value="address" label="Pin a Specific Provider">
+
+```json
+{
+  "model": "zai-org/GLM-5-FP8",
+  "messages": [{"role": "user", "content": "Hello"}],
+  "provider": {
+    "address": "0xd9966e..."
+  }
+}
+```
+
+Routes directly to a specific provider by on-chain address. **Fallback is disabled by default when pinning** — if the pinned provider fails, the request fails. Set `allow_fallbacks: true` to re-enable cross-provider retry.
+
+</TabItem>
+</Tabs>
+
+## `provider` Field Reference
+
+| Field              | Type    | Description                                                                                     |
+| ------------------ | ------- | ----------------------------------------------------------------------------------------------- |
+| `sort`             | string  | `"latency"` or `"price"`. Ignored if `address` is set.                                          |
+| `address`          | string  | Provider's on-chain address for direct routing.                                                 |
+| `allow_fallbacks`  | boolean | Allow retrying other providers on failure. Default: `true` normally, `false` when `address` is set. |
+
+## Discovering Provider Addresses
+
+List the providers serving a model with `GET /v1/providers?model_id=…` — see [Models](./models#listing-providers-for-a-model).
+
+## Related
+
+- [**Principles**](./principles) — why failover is the default
+- [**Errors**](./errors) — what `502` and `503` mean for routing

--- a/docs/developer-hub/building-on-0g/introduction.md
+++ b/docs/developer-hub/building-on-0g/introduction.md
@@ -27,7 +27,7 @@ Based on your needs, dive into:
 
 - **Dapp Migration?** → [Deploy on 0G Chain](/developer-hub/building-on-0g/contracts-on-0g/deploy-contracts)
 - **Need Storage?** → [Storage SDK Guide](/developer-hub/building-on-0g/storage/sdk)
-- **Need Compute?** → [Compute Integration](/developer-hub/building-on-0g/compute-network/inference)
+- **Need Compute?** → [Compute Router](/developer-hub/building-on-0g/compute-network/router/overview)
 - **Building a Rollup?** → [DA Integration](/developer-hub/building-on-0g/da-integration)
 - **Creating INFTs?** → [INFT Overview](/developer-hub/building-on-0g/inft/inft-overview)
 

--- a/docs/developer-hub/getting-started.md
+++ b/docs/developer-hub/getting-started.md
@@ -35,7 +35,8 @@ EVM-compatible blockchain optimized for AI
 Decentralized GPU marketplace for AI workloads
 
 - [Overview & Architecture](/developer-hub/building-on-0g/compute-network/overview)
-- [SDK Reference](/developer-hub/building-on-0g/compute-network/inference)
+- [Router API (recommended)](/developer-hub/building-on-0g/compute-network/router/overview)
+- [Direct (SDK + per-provider accounts)](/developer-hub/building-on-0g/compute-network/direct)
 - [Become a Provider](/developer-hub/building-on-0g/compute-network/inference-provider)
 
 ### 💾 0G Storage

--- a/docs/developer-hub/testnet/testnet-overview.md
+++ b/docs/developer-hub/testnet/testnet-overview.md
@@ -96,7 +96,7 @@ Visit the [0G Faucet](https://faucet.0g.ai) or the [Google Cloud Faucet](https:/
 Choose your integration:
 - [Deploy Smart Contracts](/developer-hub/building-on-0g/contracts-on-0g/deploy-contracts)
 - [Use Storage SDK](/developer-hub/building-on-0g/storage/sdk)
-- [Access Compute Network](/developer-hub/building-on-0g/compute-network/inference)
+- [Access Compute Network](/developer-hub/building-on-0g/compute-network/router/overview)
 - [Integrate DA Layer](/developer-hub/building-on-0g/da-integration)
 
 

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -101,9 +101,52 @@ const sidebars: SidebarsConfig = {
                   type: 'category',
                   label: 'For Developers',
                   items: [
-                    'developer-hub/building-on-0g/compute-network/account-management',
-                    'developer-hub/building-on-0g/compute-network/inference',
-                    'developer-hub/building-on-0g/compute-network/fine-tuning',
+                    {
+                      type: 'category',
+                      label: 'Router',
+                      link: {
+                        type: 'doc',
+                        id: 'developer-hub/building-on-0g/compute-network/router/overview',
+                      },
+                      items: [
+                        'developer-hub/building-on-0g/compute-network/router/quickstart',
+                        'developer-hub/building-on-0g/compute-network/router/principles',
+                        'developer-hub/building-on-0g/compute-network/router/models',
+                        {
+                          type: 'category',
+                          label: 'Features',
+                          items: [
+                            'developer-hub/building-on-0g/compute-network/router/features/chat-completions',
+                            'developer-hub/building-on-0g/compute-network/router/features/image-generation',
+                            'developer-hub/building-on-0g/compute-network/router/features/audio',
+                            'developer-hub/building-on-0g/compute-network/router/features/verifiable-execution',
+                          ],
+                        },
+                        'developer-hub/building-on-0g/compute-network/router/routing',
+                        'developer-hub/building-on-0g/compute-network/router/authentication',
+                        'developer-hub/building-on-0g/compute-network/router/account/deposits',
+                        'developer-hub/building-on-0g/compute-network/router/rate-limits',
+                        'developer-hub/building-on-0g/compute-network/router/errors',
+                        'developer-hub/building-on-0g/compute-network/router/comparison',
+                        'developer-hub/building-on-0g/compute-network/router/faq',
+                      ],
+                    },
+                    {
+                      type: 'category',
+                      label: 'Direct',
+                      link: {
+                        type: 'generated-index',
+                        title: 'Direct Integration',
+                        description:
+                          'Integrate with 0G Compute directly via the @0glabs/0g-serving-broker SDK: inference and fine-tuning, backed by the shared per-provider account system.',
+                        slug: '/developer-hub/building-on-0g/compute-network/direct',
+                      },
+                      items: [
+                        'developer-hub/building-on-0g/compute-network/inference',
+                        'developer-hub/building-on-0g/compute-network/fine-tuning',
+                        'developer-hub/building-on-0g/compute-network/account-management',
+                      ],
+                    },
                   ],
                 },
                 {


### PR DESCRIPTION
- Add Router section under 0G Compute (16 new pages): overview, quickstart, principles, models, chat/image/audio/verifiable-execution features, provider routing, authentication, deposits & billing, rate limits, errors, comparison, FAQ
- Restructure For Developers sidebar around integration paths: Router and Direct become siblings; under Direct, group Inference, Fine-tuning, and Account (shared per-provider sub-account system)
- Update top-level Compute overview, getting-started, introduction, testnet-overview, concepts/compute, concepts/depin to point to Router as the recommended integration path
- Rewrite ai-context.md 0G Compute section for the two integration paths
- Retarget inference.md as "Inference under Direct"; keep account-management.md as shared Direct + Fine-tuning reference
- Remove orphan marketplace.md

# Pull Request

## Description
<!-- Brief description of your changes -->

## Related Issue
Fixes #<!-- issue number -->

## Type of Change
- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Style/UI change

## Testing
- [x] Tested locally with `yarn start`
- [x] Build passes with `yarn build`
- [x] Links work correctly

## Checklist
- [x] Self-reviewed changes
- [x] No typos or errors
- [x] Follows project style
- [x] Tested locally