### PR TITLE
chore(ci): neutralize the always-failing 'Vercel – 0g-doc-new' check

### DIFF
--- a/.github/workflows/neutralize-stale-vercel-check.yml
+++ b/.github/workflows/neutralize-stale-vercel-check.yml
@@ -1,0 +1,28 @@
+# The "Vercel – 0g-doc-new" commit status comes from a stale personal Vercel
+# project (owner has left; Vercel-side access is unrecoverable) that is still
+# linked to this repo through the org's Vercel GitHub App installation. It
+# fails on every PR. GitHub commit statuses cannot be deleted, but the latest
+# write for a given context wins — so this workflow overwrites each failing
+# status with a passing one. Remove this workflow once the project is
+# disconnected on the Vercel side.
+name: Neutralize stale Vercel check
+
+on: status
+
+permissions:
+  statuses: write
+
+jobs:
+  overwrite:
+    # NB: the context string uses an en dash (–), exactly as Vercel posts it.
+    if: github.event.context == 'Vercel – 0g-doc-new' && github.event.state != 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Overwrite failing status with success
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api "repos/${{ github.repository }}/statuses/${{ github.event.sha }}" \
+            -f context='Vercel – 0g-doc-new' \
+            -f state='success' \
+            -f description='Ignored: stale Vercel project (see the Vercel – 0g-doc check instead)'


### PR DESCRIPTION
## Problem

Every PR on this repo gets a failing **Vercel – 0g-doc-new** commit status. That check comes from a stale *personal* Vercel project (`yonasws-projects/0g-doc-new`) that is still Git-linked to this repo through the org's Vercel GitHub App installation. The owner has left and their GitHub access is already revoked, but the project keeps posting failing statuses (verified on #353, which was opened after the revocation). The real deploys are the **Vercel – 0g-doc** check from the `0g-frontend` team, which is unaffected.

It cannot be disconnected from our side: there is no repo-level webhook to delete, and removing this repo from the shared Vercel GitHub App installation would also kill the legitimate `0g-doc` deployments.

## Fix

GitHub commit statuses cannot be deleted, but the latest write per `(sha, context)` pair wins. This PR adds a small `on: status` workflow that, whenever `Vercel – 0g-doc-new` posts a non-success status, immediately overwrites it with a passing one labelled *"Ignored: stale Vercel project"*.

## Notes

- The `state != 'success'` guard means the workflow's own success write does not re-trigger it (no loop).
- `on: status` workflows only run from the default branch, so this activates after merge. Existing open PRs turn green on their next status event (a re-push or Vercel retry).
- The context string uses an en dash (`–`), verified byte-for-byte against what Vercel posts.
- This is a stopgap — the clean fix is disconnecting the project inside the `yonasws-projects` Vercel account or via Vercel support. Once that happens, delete this workflow.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0gfoundation/0g-doc/355)
<!-- Reviewable:end -->
