### PR TITLE
docs: add official $0G token contract addresses (native, W0G, bridged ETH/BSC)

### DIFF
--- a/docs/ai-context.md
+++ b/docs/ai-context.md
@@ -85,6 +85,18 @@ This page provides comprehensive context about 0G infrastructure to help AI codi
 | **Compute Inference** | `0x47340d900bdFec2BD393c626E12ea0656F938d84` | Compute inference service |
 | **Compute FineTuning** | `0x4e3474095518883744ddf135b7E0A23301c7F9c0` | Compute fine-tuning service |
 
+### $0G Token Contracts
+
+$0G is the **native gas token** on 0G Mainnet (no contract address). Official token contract representations:
+
+| Network (chain ID) | Token | Address |
+|--------------------|-------|---------|
+| 0G Mainnet (16661) | W0G — Wrapped 0G | `0x1Cd0690fF9a693f5EF2dD976660a8dAFc81A109c` |
+| Ethereum (1) | 0G — official bridged token | `0x4B948d64dE1F71fCd12fB586f4c776421a35b3eE` |
+| BNB Chain (56) | 0G — official bridged token | `0x4B948d64dE1F71fCd12fB586f4c776421a35b3eE` |
+
+All 18 decimals. The bridged token shares the same address on Ethereum and BNB Chain (bridged via Stargate). Any other contract claiming to be $0G is not official.
+
 ## 0G Services Overview
 
 ### 0G Chain

--- a/docs/introduction/how-to-get-0g.md
+++ b/docs/introduction/how-to-get-0g.md
@@ -18,6 +18,18 @@ Prefer a guided path? **[get.0g.ai](https://get.0g.ai)** is the official interac
 - **Mainnet Launch**: September 2025
 :::
 
+## Official Token Contracts
+
+On the 0G Mainnet, $0G is the **native gas token** — like ETH on Ethereum, it has no contract address (some interfaces display it as `0x0000…0000`). Every official contract representation of $0G is listed below. **Any other contract claiming to be $0G, on any network, is not official.**
+
+| Network | Token | Contract Address |
+|---------|-------|------------------|
+| 0G Mainnet (chain ID 16661) | W0G — Wrapped 0G | [`0x1Cd0690fF9a693f5EF2dD976660a8dAFc81A109c`](https://chainscan.0g.ai/address/0x1Cd0690fF9a693f5EF2dD976660a8dAFc81A109c) |
+| Ethereum (chain ID 1) | 0G — official bridged token | [`0x4B948d64dE1F71fCd12fB586f4c776421a35b3eE`](https://etherscan.io/token/0x4B948d64dE1F71fCd12fB586f4c776421a35b3eE) |
+| BNB Chain (chain ID 56) | 0G — official bridged token | [`0x4B948d64dE1F71fCd12fB586f4c776421a35b3eE`](https://bscscan.com/token/0x4B948d64dE1F71fCd12fB586f4c776421a35b3eE) |
+
+All three tokens use 18 decimals. The official bridged token deliberately shares the **same address on Ethereum and BNB Chain**, and moves to and from the 0G network via [Stargate](https://stargate.finance). W0G is the canonical wrapped form of native $0G on the 0G chain — see [Wrapped 0G Base](/developer-hub/building-on-0g/contracts-on-0g/precompiles/precompiles-wrappedogbase) for details.
+
 ## Centralized Exchanges
 
 The most straightforward way to acquire $0G is through centralized exchanges. After purchasing, withdraw directly to the **0G Mainnet** (select "0G Chain" or "0G Mainnet" as the withdrawal network). All exchanges below support withdrawals to the native 0G network — always confirm the withdrawal network in-app before transferring, as availability can be paused during network upgrades.
@@ -44,7 +56,7 @@ The most straightforward way to acquire $0G is through centralized exchanges. Af
 **[Fomo](https://fomo.family)** is a social trading app (mobile and web) for buying crypto in seconds — multichain, gasless, with Apple Pay support.
 
 - **URL**: [$0G on Fomo](https://fomo.family/coin?address=0x4b948d64de1f71fcd12fb586f4c776421a35b3ee&chainId=56&r=vargs_g&source=share_link)
-- **Network**: BNB Chain (trades the bridged $0G token)
+- **Network**: BNB Chain (trades the [official bridged $0G token](#official-token-contracts))
 - **Features**: Gasless trading, Apple Pay funding, social feeds and top-trader alerts
 
 To move your $0G from BNB Chain to the native 0G network, bridge with [Stargate](https://stargate.finance).

--- a/docs/introduction/how-to-get-0g.md
+++ b/docs/introduction/how-to-get-0g.md
@@ -8,7 +8,7 @@ description: "Learn how to buy, bridge, and swap 0G tokens through exchanges, cr
 # How to Get 0G Token
 
 :::tip Interactive Guide
-Prefer a guided path? **[get.0g.ai](https://get.0g.ai)** is the official interactive guide to acquiring $0G — pick your starting point (fiat, another chain, an exchange, DeFi, or a wallet) and it walks you through step by step.
+Prefer a guided path? **[get.0g.ai](https://get.0g.ai)** is the official interactive guide to acquiring $0G. Pick your starting point (fiat, another chain, an exchange, DeFi, or a wallet) and it walks you through step by step.
 :::
 
 :::info Network Details
@@ -20,19 +20,19 @@ Prefer a guided path? **[get.0g.ai](https://get.0g.ai)** is the official interac
 
 ## Official Token Contracts
 
-On the 0G Mainnet, $0G is the **native gas token** — like ETH on Ethereum, it has no contract address (some interfaces display it as `0x0000…0000`). Every official contract representation of $0G is listed below. **Any other contract claiming to be $0G, on any network, is not official.**
+On the 0G Mainnet, the 0G token is the **native gas token**. Like ETH on Ethereum, it has no contract address (some interfaces display it as `0x0000…0000`). Every official contract representation is listed below. **Any other contract claiming to be $0G, on any network, is not official.**
 
 | Network | Token | Contract Address |
 |---------|-------|------------------|
-| 0G Mainnet (chain ID 16661) | W0G — Wrapped 0G | [`0x1Cd0690fF9a693f5EF2dD976660a8dAFc81A109c`](https://chainscan.0g.ai/address/0x1Cd0690fF9a693f5EF2dD976660a8dAFc81A109c) |
-| Ethereum (chain ID 1) | 0G — official bridged token | [`0x4B948d64dE1F71fCd12fB586f4c776421a35b3eE`](https://etherscan.io/token/0x4B948d64dE1F71fCd12fB586f4c776421a35b3eE) |
-| BNB Chain (chain ID 56) | 0G — official bridged token | [`0x4B948d64dE1F71fCd12fB586f4c776421a35b3eE`](https://bscscan.com/token/0x4B948d64dE1F71fCd12fB586f4c776421a35b3eE) |
+| 0G Mainnet (chain ID 16661) | W0G (Wrapped 0G) | [`0x1Cd0690fF9a693f5EF2dD976660a8dAFc81A109c`](https://chainscan.0g.ai/address/0x1Cd0690fF9a693f5EF2dD976660a8dAFc81A109c) |
+| Ethereum (chain ID 1) | 0G (official bridged token) | [`0x4B948d64dE1F71fCd12fB586f4c776421a35b3eE`](https://etherscan.io/token/0x4B948d64dE1F71fCd12fB586f4c776421a35b3eE) |
+| BNB Chain (chain ID 56) | 0G (official bridged token) | [`0x4B948d64dE1F71fCd12fB586f4c776421a35b3eE`](https://bscscan.com/token/0x4B948d64dE1F71fCd12fB586f4c776421a35b3eE) |
 
-All three tokens use 18 decimals. The official bridged token deliberately shares the **same address on Ethereum and BNB Chain**, and moves to and from the 0G network via [Stargate](https://stargate.finance). W0G is the canonical wrapped form of native $0G on the 0G chain — see [Wrapped 0G Base](/developer-hub/building-on-0g/contracts-on-0g/precompiles/precompiles-wrappedogbase) for details.
+All three tokens use 18 decimals. The official bridged token deliberately shares the **same address on Ethereum and BNB Chain**, and moves to and from the 0G network via [Stargate](https://stargate.finance). W0G is the canonical wrapped form of the native token on the 0G chain; see [Wrapped 0G Base](/developer-hub/building-on-0g/contracts-on-0g/precompiles/precompiles-wrappedogbase) for details.
 
 ## Centralized Exchanges
 
-The most straightforward way to acquire $0G is through centralized exchanges. After purchasing, withdraw directly to the **0G Mainnet** (select "0G Chain" or "0G Mainnet" as the withdrawal network). All exchanges below support withdrawals to the native 0G network — always confirm the withdrawal network in-app before transferring, as availability can be paused during network upgrades.
+The most straightforward way to acquire $0G is through centralized exchanges. After purchasing, withdraw directly to the **0G Mainnet** (select "0G Chain" or "0G Mainnet" as the withdrawal network). All exchanges below support withdrawals to the native 0G network. Always confirm the withdrawal network in-app before transferring, as availability can be paused during network upgrades.
 
 ### Spot Trading
 
@@ -53,13 +53,7 @@ The most straightforward way to acquire $0G is through centralized exchanges. Af
 
 ## Buy on Fomo
 
-**[Fomo](https://fomo.family)** is a social trading app (mobile and web) for buying crypto in seconds — multichain, gasless, with Apple Pay support.
-
-- **URL**: [$0G on Fomo](https://fomo.family/coin?address=0x4b948d64de1f71fcd12fb586f4c776421a35b3ee&chainId=56&r=vargs_g&source=share_link)
-- **Network**: BNB Chain (trades the [official bridged $0G token](#official-token-contracts))
-- **Features**: Gasless trading, Apple Pay funding, social feeds and top-trader alerts
-
-To move your $0G from BNB Chain to the native 0G network, bridge with [Stargate](https://stargate.finance).
+Buy the [official bridged $0G](#official-token-contracts) directly on [Fomo](https://fomo.family/coin?address=0x4b948d64de1f71fcd12fb586f4c776421a35b3ee&chainId=56&r=vargs_g&source=share_link).
 
 ## Bridge to 0G Chain
 
@@ -84,7 +78,7 @@ To move your $0G from BNB Chain to the native 0G network, bridge with [Stargate]
 ### Khalani TokenFlight (Cross-Chain Swap on 0G Hub)
 
 - **URL**: [https://hub.0g.ai/khalani/transfer](https://hub.0g.ai/khalani/transfer)
-- **Networks**: 20 chains — including Ethereum, BNB Chain, Arbitrum, Base, Solana, Monad, Bitcoin and Tron
+- **Networks**: 20 chains, including Ethereum, BNB Chain, Arbitrum, Base, Solana, Monad, Bitcoin and Tron
 - **How it works**: Intent-based routing with atomic settlement. Select a source chain and token; TokenFlight finds the best route and delivers on 0G.
 
 ### More Bridges & Aggregators
@@ -99,7 +93,7 @@ To move your $0G from BNB Chain to the native 0G network, bridge with [Stargate]
 | **[Gas.zip](https://www.gas.zip)** | Gas refuel only | Tops up a small amount of native 0G for transaction fees |
 
 :::note For developers
-[LI.FI](https://li.fi/) — the bridge & swap aggregation engine behind Jumper — supports 0G Mainnet directly (chain key `zerog`, chain ID `16661`). Use the [LI.FI API](https://docs.li.fi/) or [SDK](https://docs.li.fi/sdk/overview) to quote and execute cross-chain swaps into 0G programmatically, e.g. `GET https://li.quest/v1/quote?toChain=16661&...`.
+[LI.FI](https://li.fi/), the bridge & swap aggregation engine behind Jumper, supports 0G Mainnet directly (chain key `zerog`, chain ID `16661`). Use the [LI.FI API](https://docs.li.fi/) or [SDK](https://docs.li.fi/sdk/overview) to quote and execute cross-chain swaps into 0G programmatically, e.g. `GET https://li.quest/v1/quote?toChain=16661&...`.
 :::
 
 ## Swap on 0G Chain
@@ -121,23 +115,23 @@ To receive and hold $0G, you need a wallet that supports the 0G network.
 
 ### Supported Wallets
 
-Every wallet below detects the native $0G token automatically once the 0G network is added. "Bridged tokens" refers to W0G, USDC.e, WETH and WBTC on the 0G network.
+Every wallet below detects the native $0G token automatically once the 0G network is added.
 
-| Wallet | Add 0G Network | Token Detection |
-|--------|----------------|-----------------|
-| **[MetaMask](https://metamask.io/)** | Add manually — see [Mainnet Overview](/developer-hub/mainnet/mainnet-overview) | $0G |
-| **[Rabby](https://rabby.io/)** | Built-in | $0G and bridged tokens, with USD values |
-| **[OKX Wallet](https://www.okx.com/web3)** | Built-in | $0G (USD value) and bridged tokens |
-| **[Bitget Wallet](https://web3.bitget.com/)** | Built-in | $0G (USD value) and bridged tokens |
-| **[Zerion](https://zerion.io/)** | Built-in | $0G (USD value) and most bridged tokens |
-| **[Coinbase Wallet](https://www.coinbase.com/wallet)** | Add manually | $0G |
-| **[SafePal](https://www.safepal.com/)** | In-app network directory (App v3.9.0+) | $0G (USD value) and bridged tokens |
-| **[Trust Wallet](https://trustwallet.com/)** | Add manually | $0G |
-| **[TokenPocket](https://www.tokenpocket.pro/)** | In-app network directory | $0G |
-| **[Rainbow](https://rainbow.me/)** | Add manually | $0G |
-| **[Safe](https://safe.global/)** (multisig for teams & treasuries) | Built-in | — |
-| **[Fordefi](https://fordefi.com/)** (institutional MPC) | Built-in | — |
-| **[Ledger](https://www.ledger.com/)** (hardware wallet) | Built-in | — |
+| Wallet | Add 0G Network |
+|--------|----------------|
+| **[MetaMask](https://metamask.io/)** | Add manually (see [Mainnet Overview](/developer-hub/mainnet/mainnet-overview)) |
+| **[Rabby](https://rabby.io/)** | Built-in |
+| **[OKX Wallet](https://www.okx.com/web3)** | Built-in |
+| **[Bitget Wallet](https://web3.bitget.com/)** | Built-in |
+| **[Zerion](https://zerion.io/)** | Built-in |
+| **[Coinbase Wallet](https://www.coinbase.com/wallet)** | Add manually |
+| **[SafePal](https://www.safepal.com/)** | In-app network directory (App v3.9.0+) |
+| **[Trust Wallet](https://trustwallet.com/)** | Add manually |
+| **[TokenPocket](https://www.tokenpocket.pro/)** | In-app network directory |
+| **[Rainbow](https://rainbow.me/)** | Add manually |
+| **[Safe](https://safe.global/)** (multisig for teams & treasuries) | Built-in |
+| **[Fordefi](https://fordefi.com/)** (institutional MPC) | Built-in |
+| **[Ledger](https://www.ledger.com/)** (hardware wallet) | Built-in |
 
 ### Adding 0G Network
 


### PR DESCRIPTION
## Why

Trading venues listing the bridged $0G (e.g. [Fomo](https://fomo.family/coin?address=0x4b948d64de1f71fcd12fb586f4c776421a35b3ee&chainId=56), which lists it on BNB Chain) need **public, official documentation** confirming which contract is the genuine bridged token. Until now no docs page listed the token addresses.

## What

New **Official Token Contracts** section on [How to Get 0G Token](https://docs.0g.ai/introduction/how-to-get-0g), plus the matching table in `ai-context.md` (per repo convention, contract addresses added anywhere must land there too):

| Network (chain ID) | Token | Address |
|---|---|---|
| 0G Mainnet (16661) | W0G — Wrapped 0G | `0x1Cd0690fF9a693f5EF2dD976660a8dAFc81A109c` |
| Ethereum (1) | 0G — official bridged | `0x4B948d64dE1F71fCd12fB586f4c776421a35b3eE` |
| BNB Chain (56) | 0G — official bridged | `0x4B948d64dE1F71fCd12fB586f4c776421a35b3eE` |

Plus an explicit statement that native $0G has no contract address and that any other contract claiming to be $0G is not official. The Fomo entry now links to the section.

## Verification (every address, before publishing)

- **On-chain** `eth_call` for `name()`/`symbol()`/`decimals()` on each network's RPC: Ethereum and BSC both return `0G`/`0G`/18 at `0x4B94…b3eE`; 0G Mainnet (via `evmrpc.0g.ai`) returns `Wrapped 0G`/`W0G` at `0x1Cd0…109c`.
- **Cross-checked** against CoinGecko (`zero-gravity` platforms) and LI.FI (`li.quest/v1/token`) — all agree, including the deliberate same-address deploy on both chains.
- **W0G matches the repo's own source of truth**: [`wrappedogbase.md`](https://docs.0g.ai/developer-hub/building-on-0g/contracts-on-0g/precompiles/precompiles-wrappedogbase) already declares `0x1Cd0…109c` as the official W0G address.
- cspell + `pnpm build` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0gfoundation/0g-doc/356)
<!-- Reviewable:end -->
